### PR TITLE
feat: pause/unpause hotkeys, config auto-merge, and hide-to-tray fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ resolver = "3"
 strip = true          # Remove symbols and debug info
 lto = true            # Link-time optimization across all crates
 codegen-units = 1     # Better optimization (slower compile)
+opt-level = "z"       # Optimize for binary size
+panic = "abort"       # Remove panic unwinding machinery

--- a/crates/mosaico-core/src/action.rs
+++ b/crates/mosaico-core/src/action.rs
@@ -73,6 +73,8 @@ pub enum Action {
     MinimizeFocused,
     /// Cycle to the next layout on the focused workspace.
     CycleLayout,
+    /// Toggle hotkey pause: unregister all hotkeys (paused) or re-register them (unpaused).
+    TogglePause,
 }
 
 impl FromStr for Action {
@@ -97,6 +99,7 @@ impl FromStr for Action {
             "close-focused" => Ok(Action::CloseFocused),
             "minimize-focused" => Ok(Action::MinimizeFocused),
             "cycle-layout" => Ok(Action::CycleLayout),
+            "toggle-pause" => Ok(Action::TogglePause),
             _ => Err(format!("unknown action: {s}")),
         }
     }
@@ -112,6 +115,7 @@ impl fmt::Display for Action {
             Action::CloseFocused => write!(f, "close-focused"),
             Action::MinimizeFocused => write!(f, "minimize-focused"),
             Action::CycleLayout => write!(f, "cycle-layout"),
+            Action::TogglePause => write!(f, "toggle-pause"),
             Action::GoToWorkspace(n) => write!(f, "goto-workspace-{n}"),
             Action::SendToWorkspace(n) => write!(f, "send-to-workspace-{n}"),
         }
@@ -170,6 +174,7 @@ mod tests {
             Action::SendToWorkspace(1),
             Action::SendToWorkspace(8),
             Action::CycleLayout,
+            Action::TogglePause,
         ];
         for action in &actions {
             let s = action.to_string();

--- a/crates/mosaico-core/src/config/bar.rs
+++ b/crates/mosaico-core/src/config/bar.rs
@@ -200,6 +200,18 @@ pub enum WidgetConfig {
         #[serde(default = "default_media_max_length")]
         max_length: usize,
     },
+    /// Hotkey-paused indicator — only visible while mosaico hotkeys are paused.
+    Paused {
+        /// Whether this widget is shown.
+        #[serde(default = "default_true")]
+        enabled: bool,
+        /// Icon text prepended to the widget.
+        #[serde(default)]
+        icon: String,
+        /// Text color (hex or named). Defaults to red.
+        #[serde(default = "default_paused_color")]
+        color: String,
+    },
 }
 
 fn default_true() -> bool {
@@ -208,6 +220,10 @@ fn default_true() -> bool {
 
 fn default_update_color() -> String {
     "green".into()
+}
+
+fn default_paused_color() -> String {
+    "red".into()
 }
 
 impl WidgetConfig {
@@ -222,7 +238,8 @@ impl WidgetConfig {
             | Self::Cpu { icon, .. }
             | Self::Update { icon, .. }
             | Self::ActiveWindow { icon, .. }
-            | Self::Media { icon, .. } => icon,
+            | Self::Media { icon, .. }
+            | Self::Paused { icon, .. } => icon,
         }
     }
 
@@ -237,7 +254,8 @@ impl WidgetConfig {
             | Self::Cpu { enabled, .. }
             | Self::Update { enabled, .. }
             | Self::ActiveWindow { enabled, .. }
-            | Self::Media { enabled, .. } => *enabled,
+            | Self::Media { enabled, .. }
+            | Self::Paused { enabled, .. } => *enabled,
         }
     }
 
@@ -252,7 +270,8 @@ impl WidgetConfig {
             | Self::Cpu { color, .. }
             | Self::Update { color, .. }
             | Self::ActiveWindow { color, .. }
-            | Self::Media { color, .. } => color,
+            | Self::Media { color, .. }
+            | Self::Paused { color, .. } => color,
         }
     }
 
@@ -267,7 +286,8 @@ impl WidgetConfig {
             | Self::Cpu { color, .. }
             | Self::Update { color, .. }
             | Self::ActiveWindow { color, .. }
-            | Self::Media { color, .. } => color,
+            | Self::Media { color, .. }
+            | Self::Paused { color, .. } => color,
         };
         if !color.is_empty()
             && let Some(hex) = theme.named_color(color)
@@ -315,6 +335,11 @@ fn default_left_widgets() -> Vec<WidgetConfig> {
 
 fn default_right_widgets() -> Vec<WidgetConfig> {
     vec![
+        WidgetConfig::Paused {
+            enabled: true,
+            icon: String::new(),
+            color: default_paused_color(),
+        },
         WidgetConfig::Clock {
             enabled: true,
             format: default_clock_format(),
@@ -474,7 +499,7 @@ mod tests {
         assert_eq!(config.background_opacity, 0);
         assert!(config.monitors.is_empty());
         assert_eq!(config.left.len(), 3);
-        assert_eq!(config.right.len(), 5);
+        assert_eq!(config.right.len(), 6);
     }
 
     #[test]

--- a/crates/mosaico-core/src/config/loader.rs
+++ b/crates/mosaico-core/src/config/loader.rs
@@ -121,7 +121,8 @@ pub fn merge_missing_keybindings() -> Vec<Keybinding> {
     }
 
     // Append missing bindings to the file.
-    let mut addition = String::from("\n# Added automatically — new defaults from this version of mosaico\n");
+    let mut addition =
+        String::from("\n# Added automatically — new defaults from this version of mosaico\n");
     for kb in &missing {
         addition.push_str(&keybinding_toml_entry(kb));
     }
@@ -245,9 +246,9 @@ pub fn merge_missing_bar_widgets() -> super::bar::BarConfig {
     };
 
     let toml_addition = match toml::to_string(&diff) {
-        Ok(s) => format!(
-            "\n# Added automatically — new defaults from this version of mosaico\n{s}"
-        ),
+        Ok(s) => {
+            format!("\n# Added automatically — new defaults from this version of mosaico\n{s}")
+        }
         Err(e) => {
             eprintln!("Warning: could not serialize missing bar widgets: {e}");
             return user;

--- a/crates/mosaico-core/src/config/loader.rs
+++ b/crates/mosaico-core/src/config/loader.rs
@@ -88,6 +88,195 @@ pub fn load_keybindings() -> Vec<Keybinding> {
     )
 }
 
+/// Loads keybindings and appends any missing defaults to the user's file.
+///
+/// Compares the user's configured actions against the built-in defaults.
+/// Any default action not already bound by the user is appended to the
+/// keybindings file so new bindings from future versions are picked up
+/// automatically, without overwriting anything the user has configured.
+///
+/// Falls back to `load_keybindings()` if the file cannot be read or written.
+pub fn merge_missing_keybindings() -> Vec<Keybinding> {
+    let path = match keybindings_path() {
+        Some(p) if p.exists() => p,
+        _ => return load_keybindings(),
+    };
+
+    let user = match try_load_keybindings() {
+        Ok(kb) => kb,
+        Err(e) => {
+            eprintln!("Warning: {e}");
+            return keybinding::defaults();
+        }
+    };
+
+    let defaults = keybinding::defaults();
+    let missing: Vec<&Keybinding> = defaults
+        .iter()
+        .filter(|d| !user.iter().any(|u| u.action == d.action))
+        .collect();
+
+    if missing.is_empty() {
+        return user;
+    }
+
+    // Append missing bindings to the file.
+    let mut addition = String::from("\n# Added automatically — new defaults from this version of mosaico\n");
+    for kb in &missing {
+        addition.push_str(&keybinding_toml_entry(kb));
+    }
+
+    match std::fs::OpenOptions::new().append(true).open(&path) {
+        Ok(mut f) => {
+            use std::io::Write;
+            if let Err(e) = f.write_all(addition.as_bytes()) {
+                eprintln!("Warning: could not append missing keybindings: {e}");
+                return user;
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: could not open keybindings file for appending: {e}");
+            return user;
+        }
+    }
+
+    eprintln!(
+        "Info: appended {} missing default keybinding(s) to keybindings.toml",
+        missing.len()
+    );
+
+    // Return the full merged set.
+    let mut merged = user;
+    merged.extend(missing.into_iter().cloned());
+    merged
+}
+
+/// Formats a single keybinding as a `[[keybinding]]` TOML entry.
+fn keybinding_toml_entry(kb: &Keybinding) -> String {
+    let modifiers: Vec<String> = kb
+        .modifiers
+        .iter()
+        .map(|m| {
+            let s = match m {
+                keybinding::Modifier::Alt => "alt",
+                keybinding::Modifier::Shift => "shift",
+                keybinding::Modifier::Ctrl => "ctrl",
+                keybinding::Modifier::Win => "win",
+            };
+            format!("\"{s}\"")
+        })
+        .collect();
+    format!(
+        "\n[[keybinding]]\naction = \"{}\"\nkey = \"{}\"\nmodifiers = [{}]\n",
+        kb.action,
+        kb.key,
+        modifiers.join(", ")
+    )
+}
+
+/// Loads bar config and appends any missing default widgets to the user's file.
+///
+/// Compares the user's `[[left]]` and `[[right]]` widget lists against the
+/// built-in defaults by widget type. Any default widget type not already
+/// present in the user's file is appended so new widgets from future versions
+/// are picked up automatically, without overwriting anything the user has set.
+///
+/// Falls back to `load_bar()` if the file cannot be read or written.
+pub fn merge_missing_bar_widgets() -> super::bar::BarConfig {
+    use super::bar::{BarConfig, WidgetConfig};
+    use serde::Serialize;
+
+    let path = match bar_path() {
+        Some(p) if p.exists() => p,
+        _ => return load_bar(),
+    };
+
+    let mut user = match try_load_bar() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Warning: {e}");
+            return BarConfig::default();
+        }
+    };
+
+    let defaults = BarConfig::default();
+
+    // Find widget types (by enum discriminant) present in defaults but missing
+    // from the user's left/right lists. Users may intentionally remove widgets,
+    // but a type that never existed before must be a new default.
+    let missing_left: Vec<&WidgetConfig> = defaults
+        .left
+        .iter()
+        .filter(|d| {
+            !user
+                .left
+                .iter()
+                .any(|u| std::mem::discriminant(u) == std::mem::discriminant(*d))
+        })
+        .collect();
+
+    let missing_right: Vec<&WidgetConfig> = defaults
+        .right
+        .iter()
+        .filter(|d| {
+            !user
+                .right
+                .iter()
+                .any(|u| std::mem::discriminant(u) == std::mem::discriminant(*d))
+        })
+        .collect();
+
+    if missing_left.is_empty() && missing_right.is_empty() {
+        return user;
+    }
+
+    // Serialize missing entries as TOML using a wrapper struct.
+    #[derive(Serialize)]
+    struct BarSideDiff<'a> {
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        left: Vec<&'a WidgetConfig>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        right: Vec<&'a WidgetConfig>,
+    }
+
+    let diff = BarSideDiff {
+        left: missing_left.clone(),
+        right: missing_right.clone(),
+    };
+
+    let toml_addition = match toml::to_string(&diff) {
+        Ok(s) => format!(
+            "\n# Added automatically — new defaults from this version of mosaico\n{s}"
+        ),
+        Err(e) => {
+            eprintln!("Warning: could not serialize missing bar widgets: {e}");
+            return user;
+        }
+    };
+
+    match std::fs::OpenOptions::new().append(true).open(&path) {
+        Ok(mut f) => {
+            use std::io::Write;
+            if let Err(e) = f.write_all(toml_addition.as_bytes()) {
+                eprintln!("Warning: could not append missing bar widgets: {e}");
+                return user;
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: could not open bar.toml for appending: {e}");
+            return user;
+        }
+    }
+
+    let total = missing_left.len() + missing_right.len();
+    eprintln!("Info: appended {total} missing default bar widget(s) to bar.toml");
+
+    // Return merged config.
+    user.left.extend(missing_left.into_iter().cloned());
+    user.right.extend(missing_right.into_iter().cloned());
+    user
+}
+
 /// Tries to load and parse `rules.toml`.
 ///
 /// Returns the parsed rules or an error string.

--- a/crates/mosaico-core/src/config/mod.rs
+++ b/crates/mosaico-core/src/config/mod.rs
@@ -21,8 +21,9 @@ pub use bar::{BarColors, BarConfig, WidgetConfig};
 pub use keybinding::{Keybinding, Modifier};
 pub use loader::{
     bar_path, config_dir, config_path, keybindings_path, load, load_bar, load_keybindings,
-    load_merged_rules, load_rules, load_user_rules, rules_path, try_load, try_load_bar,
-    try_load_keybindings, try_load_rules, try_load_user_rules, user_rules_path,
+    load_merged_rules, load_rules, load_user_rules, merge_missing_bar_widgets,
+    merge_missing_keybindings, rules_path, try_load, try_load_bar, try_load_keybindings,
+    try_load_rules, try_load_user_rules, user_rules_path,
 };
 pub use rules::{WindowRule, default_rules, should_manage, validate_rules};
 pub use theme::{Theme, ThemeConfig};

--- a/crates/mosaico-core/src/config/template_bar.rs
+++ b/crates/mosaico-core/src/config/template_bar.rs
@@ -100,6 +100,11 @@ type = \"update\"\n\
 icon = \"\\uF019\"\n\
 color = \"green\"  # custom color for text and border (hex or named)\n\
 \n\
+[[right]]\n\
+type = \"paused\"\n\
+# enabled = true  # auto-hidden when hotkeys are not paused\n\
+color = \"red\"  # shown in red while mosaico hotkeys are paused\n\
+\n\
 # Media widget -- shows currently playing track from Spotify, YouTube Music, etc.\n\
 # Auto-hidden when nothing is playing.\n\
 # [[right]]\n\

--- a/crates/mosaico-core/src/ipc.rs
+++ b/crates/mosaico-core/src/ipc.rs
@@ -19,6 +19,10 @@ pub enum Command {
     },
     /// Dump the daemon's internal workspace state for debugging.
     Inspect,
+    /// Pause all hotkeys (unregister all except toggle-pause).
+    PauseHotkeys,
+    /// Re-register all hotkeys that were paused.
+    UnpauseHotkeys,
 }
 
 /// A response sent from the daemon back to the CLI.

--- a/crates/mosaico-windows/src/bar/widgets/mod.rs
+++ b/crates/mosaico-windows/src/bar/widgets/mod.rs
@@ -11,6 +11,7 @@ pub mod cpu;
 pub mod date;
 pub mod layout;
 pub mod media;
+pub mod paused;
 pub mod ram;
 mod system;
 pub mod update;
@@ -36,6 +37,8 @@ pub struct BarState {
     pub focused_hwnd: Option<usize>,
     /// Formatted media info (e.g. "Artist - Title"). Empty = nothing playing.
     pub media_text: String,
+    /// Whether mosaico hotkeys are currently paused.
+    pub paused: bool,
 }
 
 impl Default for BarState {
@@ -49,6 +52,7 @@ impl Default for BarState {
             update_text: String::new(),
             focused_hwnd: None,
             media_text: String::new(),
+            paused: false,
         }
     }
 }
@@ -103,7 +107,11 @@ fn should_skip(widget: &WidgetConfig, state: &BarState) -> bool {
         return true;
     }
     // Hide the media widget when nothing is playing.
-    matches!(widget, WidgetConfig::Media { .. }) && state.media_text.is_empty()
+    if matches!(widget, WidgetConfig::Media { .. }) && state.media_text.is_empty() {
+        return true;
+    }
+    // Hide the paused widget when hotkeys are not paused.
+    matches!(widget, WidgetConfig::Paused { .. }) && !state.paused
 }
 
 // -- shared pill rendering ------------------------------------------------
@@ -234,6 +242,7 @@ fn widget_text(state: &BarState, widget: &WidgetConfig) -> String {
         WidgetConfig::Cpu { .. } => cpu::text(state.cpu_usage),
         WidgetConfig::Update { .. } => update::text(state),
         WidgetConfig::Media { max_length, .. } => media::text(state, *max_length),
+        WidgetConfig::Paused { .. } => paused::text(state),
     }
 }
 

--- a/crates/mosaico-windows/src/bar/widgets/paused.rs
+++ b/crates/mosaico-windows/src/bar/widgets/paused.rs
@@ -1,0 +1,11 @@
+//! Paused indicator widget — visible only while mosaico hotkeys are paused.
+
+use super::BarState;
+
+/// Returns "PAUSED" when hotkeys are paused, empty string otherwise.
+///
+/// The widget is hidden by `should_skip` when `state.paused` is false,
+/// so this function will only be called when paused is true.
+pub fn text(_state: &BarState) -> String {
+    "PAUSED".to_string()
+}

--- a/crates/mosaico-windows/src/daemon_loop.rs
+++ b/crates/mosaico-windows/src/daemon_loop.rs
@@ -19,7 +19,7 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
     let config = config::load();
     mosaico_core::log::init(&config.logging);
 
-    let keybindings = config::load_keybindings();
+    let keybindings = config::merge_missing_keybindings();
     let rules = config::load_merged_rules();
 
     mosaico_core::log_info!("Daemon started (PID: {})", std::process::id());
@@ -33,7 +33,7 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
 
     let mut current_theme = config.theme.resolve();
 
-    let bar_config = config::load_bar();
+    let bar_config = config::merge_missing_bar_widgets();
     let monitor_rects: Vec<_> = monitor::enumerate_monitors()?
         .iter()
         .map(|m| m.work_area)
@@ -62,7 +62,7 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
     daemon_threads::spawn_rules_download(tx.clone());
 
     let get_update = || update_text.lock().map_or(String::new(), |t| t.clone());
-    bar_mgr.update(&manager.bar_states(&get_update()));
+    bar_mgr.update(&manager.bar_states(&get_update(), false));
     mosaico_core::log_info!("Managing {} windows", manager.window_count());
 
     // Start the Win32 event loop + hotkeys on its own thread.
@@ -100,6 +100,7 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
     // remain responsive even when the event queue is flooded.
     let mut events = Vec::new();
     let mut should_stop = false;
+    let mut hotkeys_paused = false;
 
     while !should_stop {
         // Block until at least one message arrives.
@@ -125,6 +126,8 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
                         action,
                         &mut manager,
                         &mut bar_mgr,
+                        &event_loop,
+                        &mut hotkeys_paused,
                         &get_update,
                     );
                 }
@@ -133,6 +136,8 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
                         &command,
                         &mut manager,
                         &mut bar_mgr,
+                        &event_loop,
+                        &mut hotkeys_paused,
                         &get_update,
                     ) {
                         let _ = reply_tx.send(response);
@@ -148,11 +153,17 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
                         &mut bar_mgr,
                         &mut current_theme,
                         &event_loop,
+                        hotkeys_paused,
                         &get_update,
                     );
                 }
                 DaemonMsg::Tick => {
-                    daemon_loop_handlers::handle_tick(&mut manager, &mut bar_mgr, &get_update);
+                    daemon_loop_handlers::handle_tick(
+                        &mut manager,
+                        &mut bar_mgr,
+                        hotkeys_paused,
+                        &get_update,
+                    );
                 }
             }
         }
@@ -174,7 +185,7 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
             );
         }
         if needs_bar_update {
-            bar_mgr.update(&manager.bar_states(&get_update()));
+            bar_mgr.update(&manager.bar_states(&get_update(), hotkeys_paused));
         }
     }
 

--- a/crates/mosaico-windows/src/daemon_loop_handlers.rs
+++ b/crates/mosaico-windows/src/daemon_loop_handlers.rs
@@ -56,16 +56,33 @@ pub(super) fn handle_action(
     action: mosaico_core::Action,
     manager: &mut TilingManager,
     bar_mgr: &mut BarManager,
+    event_loop: &crate::event_loop::EventLoopHandle,
+    hotkeys_paused: &mut bool,
     get_update: &dyn Fn() -> String,
 ) {
+    if action == mosaico_core::Action::TogglePause {
+        if *hotkeys_paused {
+            event_loop.unpause_hotkeys();
+            *hotkeys_paused = false;
+            mosaico_core::log_info!("Hotkeys unpaused");
+        } else {
+            event_loop.pause_hotkeys();
+            *hotkeys_paused = true;
+            mosaico_core::log_info!("Hotkeys paused");
+        }
+        bar_mgr.update(&manager.bar_states(&get_update(), *hotkeys_paused));
+        return;
+    }
     manager.handle_action(&action);
-    bar_mgr.update(&manager.bar_states(&get_update()));
+    bar_mgr.update(&manager.bar_states(&get_update(), *hotkeys_paused));
 }
 
 pub(super) fn handle_command(
     command: &Command,
     manager: &mut TilingManager,
     bar_mgr: &mut BarManager,
+    event_loop: &crate::event_loop::EventLoopHandle,
+    hotkeys_paused: &mut bool,
     get_update: &dyn Fn() -> String,
 ) -> Option<Response> {
     match command {
@@ -82,10 +99,28 @@ pub(super) fn handle_command(
         }
         Command::Action { action } => {
             manager.handle_action(action);
-            bar_mgr.update(&manager.bar_states(&get_update()));
+            bar_mgr.update(&manager.bar_states(&get_update(), *hotkeys_paused));
             Some(Response::ok())
         }
         Command::Inspect => Some(Response::ok_with_message(manager.inspect_state())),
+        Command::PauseHotkeys => {
+            if !*hotkeys_paused {
+                event_loop.pause_hotkeys();
+                *hotkeys_paused = true;
+                mosaico_core::log_info!("Hotkeys paused via CLI");
+            }
+            bar_mgr.update(&manager.bar_states(&get_update(), *hotkeys_paused));
+            Some(Response::ok_with_message("Hotkeys paused"))
+        }
+        Command::UnpauseHotkeys => {
+            if *hotkeys_paused {
+                event_loop.unpause_hotkeys();
+                *hotkeys_paused = false;
+                mosaico_core::log_info!("Hotkeys unpaused via CLI");
+            }
+            bar_mgr.update(&manager.bar_states(&get_update(), *hotkeys_paused));
+            Some(Response::ok_with_message("Hotkeys unpaused"))
+        }
     }
 }
 
@@ -95,6 +130,7 @@ pub(super) fn handle_reload(
     bar_mgr: &mut BarManager,
     current_theme: &mut mosaico_core::config::Theme,
     event_loop: &crate::event_loop::EventLoopHandle,
+    hotkeys_paused: bool,
     get_update: &dyn Fn() -> String,
 ) {
     match reload {
@@ -104,7 +140,7 @@ pub(super) fn handle_reload(
             event_loop.toggle_focus_follows_mouse(cfg.mouse.focus_follows_mouse);
             // Theme may have changed — re-resolve bar colors.
             bar_mgr.resolve_colors(*current_theme);
-            bar_mgr.update(&manager.bar_states(&get_update()));
+            bar_mgr.update(&manager.bar_states(&get_update(), hotkeys_paused));
         }
         crate::config_watcher::ConfigReload::Rules(rules) => {
             manager.reload_rules(rules);
@@ -114,7 +150,7 @@ pub(super) fn handle_reload(
             bar_mgr.resolve_colors(*current_theme);
             let indices = bar_mgr.bar_monitor_indices().to_vec();
             manager.reset_and_adjust_work_areas(new_height, &indices);
-            bar_mgr.update(&manager.bar_states(&get_update()));
+            bar_mgr.update(&manager.bar_states(&get_update(), hotkeys_paused));
         }
     }
 }
@@ -122,7 +158,8 @@ pub(super) fn handle_reload(
 pub(super) fn handle_tick(
     manager: &mut TilingManager,
     bar_mgr: &mut BarManager,
+    hotkeys_paused: bool,
     get_update: &dyn Fn() -> String,
 ) {
-    bar_mgr.update(&manager.bar_states(&get_update()));
+    bar_mgr.update(&manager.bar_states(&get_update(), hotkeys_paused));
 }

--- a/crates/mosaico-windows/src/event_loop.rs
+++ b/crates/mosaico-windows/src/event_loop.rs
@@ -111,7 +111,7 @@ pub fn start(
         let _ = ready_tx.send(Ok((thread_id, event_sink.0 as usize)));
 
         // Run the message pump with hotkey dispatching.
-        event_loop_message_pump::run_message_pump(&hotkeys);
+        event_loop_message_pump::run_message_pump(&mut hotkeys);
 
         // Cleanup: destroy event sink, hotkeys unregistered in Drop.
         if !event_sink.is_invalid() {
@@ -149,6 +149,44 @@ pub struct EventLoopHandle {
 }
 
 impl EventLoopHandle {
+    /// Pauses all hotkeys (unregisters all except toggle-pause).
+    pub fn pause_hotkeys(&self) {
+        // SAFETY: PostThreadMessageW sends a thread message that is picked up
+        // by GetMessageW in the event loop's message pump (run_message_pump).
+        unsafe {
+            let _ = PostThreadMessageW(
+                self.thread_id,
+                event_loop_message_pump::WM_HOTKEY_PAUSE,
+                WPARAM(1),
+                LPARAM(0),
+            );
+        }
+    }
+
+    /// Unpauses all hotkeys (re-registers all previously paused hotkeys).
+    pub fn unpause_hotkeys(&self) {
+        unsafe {
+            let _ = PostThreadMessageW(
+                self.thread_id,
+                event_loop_message_pump::WM_HOTKEY_PAUSE,
+                WPARAM(0),
+                LPARAM(0),
+            );
+        }
+    }
+
+    /// Toggles hotkey pause state.
+    pub fn toggle_pause_hotkeys(&self) {
+        unsafe {
+            let _ = PostThreadMessageW(
+                self.thread_id,
+                event_loop_message_pump::WM_HOTKEY_PAUSE,
+                WPARAM(2),
+                LPARAM(0),
+            );
+        }
+    }
+
     /// Enables or disables focus-follows-mouse on the event loop thread.
     pub fn toggle_focus_follows_mouse(&self, enabled: bool) {
         if self.event_sink == 0 {

--- a/crates/mosaico-windows/src/event_loop.rs
+++ b/crates/mosaico-windows/src/event_loop.rs
@@ -165,6 +165,8 @@ impl EventLoopHandle {
 
     /// Unpauses all hotkeys (re-registers all previously paused hotkeys).
     pub fn unpause_hotkeys(&self) {
+        // SAFETY: PostThreadMessageW sends a thread message that is picked up
+        // by GetMessageW in the event loop's message pump (run_message_pump).
         unsafe {
             let _ = PostThreadMessageW(
                 self.thread_id,
@@ -177,6 +179,8 @@ impl EventLoopHandle {
 
     /// Toggles hotkey pause state.
     pub fn toggle_pause_hotkeys(&self) {
+        // SAFETY: PostThreadMessageW sends a thread message that is picked up
+        // by GetMessageW in the event loop's message pump (run_message_pump).
         unsafe {
             let _ = PostThreadMessageW(
                 self.thread_id,

--- a/crates/mosaico-windows/src/event_loop_message_pump.rs
+++ b/crates/mosaico-windows/src/event_loop_message_pump.rs
@@ -1,13 +1,18 @@
 use windows::Win32::UI::WindowsAndMessaging::{
-    DispatchMessageW, GetMessageW, MSG, PM_REMOVE, PeekMessageW, TranslateMessage, WM_HOTKEY,
+    DispatchMessageW, GetMessageW, MSG, PM_REMOVE, PeekMessageW, TranslateMessage, WM_APP,
+    WM_HOTKEY,
 };
 
 use crate::hotkey::HotkeyManager;
 
+/// `PostThreadMessageW` message for pause/unpause control.
+/// wParam: 0 = unpause, 1 = pause, 2 = toggle.
+pub(crate) const WM_HOTKEY_PAUSE: u32 = WM_APP + 2;
+
 /// The Win32 message pump. Prioritises hotkey messages so that
 /// keyboard shortcuts remain responsive even when the event queue
 /// is flooded (e.g. during a virus scan or heavy WPF event storm).
-pub(crate) fn run_message_pump(hotkeys: &HotkeyManager) {
+pub(crate) fn run_message_pump(hotkeys: &mut HotkeyManager) {
     let mut msg = MSG::default();
 
     loop {
@@ -28,6 +33,15 @@ pub(crate) fn run_message_pump(hotkeys: &HotkeyManager) {
 
         if msg.message == WM_HOTKEY {
             hotkeys.dispatch(msg.wParam.0 as i32);
+            continue;
+        }
+
+        if msg.message == WM_HOTKEY_PAUSE {
+            match msg.wParam.0 {
+                0 => hotkeys.unpause(),
+                1 => hotkeys.pause(),
+                _ => hotkeys.toggle_pause(),
+            }
             continue;
         }
 

--- a/crates/mosaico-windows/src/hotkey.rs
+++ b/crates/mosaico-windows/src/hotkey.rs
@@ -64,7 +64,8 @@ impl HotkeyManager {
             self.register(id, modifiers, vk, binding.action);
         }
 
-        self.pause_hotkey_id = self.hotkeys
+        self.pause_hotkey_id = self
+            .hotkeys
             .iter()
             .find(|h| h.action == Action::TogglePause)
             .map(|h| h.id);
@@ -91,7 +92,12 @@ impl HotkeyManager {
             return;
         }
 
-        self.hotkeys.push(Hotkey { id, modifiers, vk, action });
+        self.hotkeys.push(Hotkey {
+            id,
+            modifiers,
+            vk,
+            action,
+        });
     }
 
     /// Returns true if hotkeys are currently paused.
@@ -136,7 +142,10 @@ impl HotkeyManager {
             // current thread's message queue using the original id, modifiers, vk.
             let result = unsafe { RegisterHotKey(None, hotkey.id, hotkey.modifiers, hotkey.vk) };
             if result.is_err() {
-                eprintln!("Failed to re-register hotkey {} (vk=0x{:02X})", hotkey.id, hotkey.vk);
+                eprintln!(
+                    "Failed to re-register hotkey {} (vk=0x{:02X})",
+                    hotkey.id, hotkey.vk
+                );
             }
         }
     }

--- a/crates/mosaico-windows/src/hotkey.rs
+++ b/crates/mosaico-windows/src/hotkey.rs
@@ -12,6 +12,8 @@ use crate::keys;
 /// A registered global hotkey.
 struct Hotkey {
     id: i32,
+    modifiers: HOT_KEY_MODIFIERS,
+    vk: u32,
     action: Action,
 }
 
@@ -23,6 +25,8 @@ struct Hotkey {
 pub struct HotkeyManager {
     hotkeys: Vec<Hotkey>,
     sender: Sender<Action>,
+    paused: bool,
+    pause_hotkey_id: Option<i32>,
 }
 
 impl HotkeyManager {
@@ -33,6 +37,8 @@ impl HotkeyManager {
         Self {
             hotkeys: Vec::new(),
             sender,
+            paused: false,
+            pause_hotkey_id: None,
         }
     }
 
@@ -57,6 +63,11 @@ impl HotkeyManager {
 
             self.register(id, modifiers, vk, binding.action);
         }
+
+        self.pause_hotkey_id = self.hotkeys
+            .iter()
+            .find(|h| h.action == Action::TogglePause)
+            .map(|h| h.id);
     }
 
     /// Dispatches a `WM_HOTKEY` message by hotkey ID.
@@ -80,7 +91,63 @@ impl HotkeyManager {
             return;
         }
 
-        self.hotkeys.push(Hotkey { id, action });
+        self.hotkeys.push(Hotkey { id, modifiers, vk, action });
+    }
+
+    /// Returns true if hotkeys are currently paused.
+    pub fn is_paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Unregisters all hotkeys except the toggle-pause one (if configured).
+    ///
+    /// No-op if already paused. When no `toggle-pause` keybinding is configured,
+    /// all hotkeys are unregistered — the user must unpause via the CLI.
+    pub fn pause(&mut self) {
+        if self.paused {
+            return;
+        }
+        self.paused = true;
+        for hotkey in &self.hotkeys {
+            if Some(hotkey.id) == self.pause_hotkey_id {
+                continue;
+            }
+            // SAFETY: UnregisterHotKey removes a previously registered hotkey.
+            // Failures are ignored — the OS will silently release it on process exit.
+            unsafe {
+                let _ = UnregisterHotKey(None, hotkey.id);
+            }
+        }
+    }
+
+    /// Re-registers all hotkeys that were unregistered by `pause()`.
+    ///
+    /// No-op if not paused.
+    pub fn unpause(&mut self) {
+        if !self.paused {
+            return;
+        }
+        self.paused = false;
+        for hotkey in &self.hotkeys {
+            if Some(hotkey.id) == self.pause_hotkey_id {
+                continue;
+            }
+            // SAFETY: RegisterHotKey registers a system-wide hotkey on the
+            // current thread's message queue using the original id, modifiers, vk.
+            let result = unsafe { RegisterHotKey(None, hotkey.id, hotkey.modifiers, hotkey.vk) };
+            if result.is_err() {
+                eprintln!("Failed to re-register hotkey {} (vk=0x{:02X})", hotkey.id, hotkey.vk);
+            }
+        }
+    }
+
+    /// Toggles pause state: pauses if unpaused, unpauses if paused.
+    pub fn toggle_pause(&mut self) {
+        if self.paused {
+            self.unpause();
+        } else {
+            self.pause();
+        }
     }
 }
 

--- a/crates/mosaico-windows/src/tiling/event_handler.rs
+++ b/crates/mosaico-windows/src/tiling/event_handler.rs
@@ -1,6 +1,6 @@
 //! Event handling for the tiling manager.
 
-use mosaico_core::WindowEvent;
+use mosaico_core::{Window as _, WindowEvent};
 
 use crate::frame;
 use crate::window::Window;
@@ -56,8 +56,10 @@ impl TilingManager {
                 if self.hidden_by_switch.contains(hwnd) {
                     return;
                 }
-                if Window::from_raw(*hwnd).is_valid() {
-                    mosaico_core::log_debug!("hide-ignored 0x{:X} (window still valid)", hwnd);
+                // Skip spurious hides (e.g. Chromium repainting a child surface):
+                // a real hide-to-tray leaves IsWindowVisible false.
+                if Window::from_raw(*hwnd).is_visible() {
+                    mosaico_core::log_debug!("hide-ignored 0x{:X} (still visible)", hwnd);
                     return;
                 }
                 frame::reset_corner_preference(Window::from_raw(*hwnd).hwnd());
@@ -244,11 +246,24 @@ impl TilingManager {
             self.monitors[mon_idx].workspaces[ws_idx].set_monocle_window(None);
         }
 
+        let on_active = ws_idx == self.monitors[mon_idx].active_workspace;
+
         if self.focused_window == Some(hwnd) {
             self.focused_window = None;
+            // Promote a sibling to focus so the border stays visible.
+            if on_active {
+                let ws = &self.monitors[mon_idx].workspaces[ws_idx];
+                let replacement = ws
+                    .last_focused()
+                    .filter(|&h| ws.contains(h))
+                    .or_else(|| ws.handles().first().copied());
+                if let Some(new_hwnd) = replacement {
+                    self.focus_and_update_border(new_hwnd);
+                }
+            }
         }
 
-        if ws_idx == self.monitors[mon_idx].active_workspace {
+        if on_active {
             self.apply_layout_on(mon_idx);
         }
     }

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -189,6 +189,8 @@ impl TilingManager {
             Action::CycleLayout => self.cycle_layout(),
             Action::GoToWorkspace(n) => self.goto_workspace(*n),
             Action::SendToWorkspace(n) => self.send_to_workspace(*n),
+            // TogglePause is handled by the daemon before reaching here.
+            Action::TogglePause => {}
         }
     }
 
@@ -264,7 +266,7 @@ impl TilingManager {
     }
 
     /// Returns a snapshot of bar state for each monitor.
-    pub fn bar_states(&self, update_text: &str) -> Vec<BarState> {
+    pub fn bar_states(&self, update_text: &str, paused: bool) -> Vec<BarState> {
         self.monitors
             .iter()
             .enumerate()
@@ -281,6 +283,7 @@ impl TilingManager {
                     None
                 },
                 media_text: String::new(),
+                paused,
             })
             .collect()
     }

--- a/crates/mosaico/src/commands/mod.rs
+++ b/crates/mosaico/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod autostart;
+pub mod pause;
 pub mod banner;
 pub mod daemon;
 pub mod debug;

--- a/crates/mosaico/src/commands/mod.rs
+++ b/crates/mosaico/src/commands/mod.rs
@@ -1,12 +1,12 @@
 pub mod action;
 pub mod autostart;
-pub mod pause;
 pub mod banner;
 pub mod daemon;
 pub mod debug;
 pub mod doctor;
 mod doctor_runtime;
 pub mod init;
+pub mod pause;
 pub mod start;
 pub mod status;
 pub mod stop;

--- a/crates/mosaico/src/commands/pause.rs
+++ b/crates/mosaico/src/commands/pause.rs
@@ -1,0 +1,38 @@
+use mosaico_core::ipc::ResponseStatus;
+
+/// Sends a PauseHotkeys command to the running daemon.
+pub fn pause() {
+    send(mosaico_core::Command::PauseHotkeys);
+}
+
+/// Sends an UnpauseHotkeys command to the running daemon.
+pub fn unpause() {
+    send(mosaico_core::Command::UnpauseHotkeys);
+}
+
+fn send(command: mosaico_core::Command) {
+    if !mosaico_windows::ipc::is_daemon_running() {
+        eprintln!("Mosaico is not running.");
+        std::process::exit(1);
+    }
+
+    match mosaico_windows::ipc::send_command(&command) {
+        Ok(response) => {
+            if response.status == ResponseStatus::Ok {
+                if let Some(msg) = response.message {
+                    println!("{msg}");
+                }
+            } else {
+                eprintln!(
+                    "Error: {}",
+                    response.message.unwrap_or("unknown error".into()),
+                );
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to send command: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/mosaico/src/main.rs
+++ b/crates/mosaico/src/main.rs
@@ -52,6 +52,10 @@ enum Commands {
         #[command(subcommand)]
         command: DebugCommands,
     },
+    /// Pause all mosaico hotkeys until unpaused
+    Pause,
+    /// Resume all mosaico hotkeys
+    Unpause,
     /// Update mosaico to the latest release
     Update {
         /// Reinstall even if already on the latest version
@@ -152,6 +156,8 @@ fn main() {
             AutostartCommands::Disable => commands::autostart::disable(),
             AutostartCommands::Status => commands::autostart::status(),
         },
+        Commands::Pause => commands::pause::pause(),
+        Commands::Unpause => commands::pause::unpause(),
         Commands::Banner => commands::banner::execute(),
         Commands::Update { force } => commands::update::execute(force),
         Commands::Daemon => commands::daemon::execute(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ dedicated handler module under `crates/mosaico/src/commands/`.
 | `crates/mosaico/src/commands/doctor.rs` | `mosaico doctor` handler |
 | `crates/mosaico/src/commands/daemon.rs` | `mosaico daemon` handler (hidden) |
 | `crates/mosaico/src/commands/action.rs` | `mosaico action <verb>` handler |
+| `crates/mosaico/src/commands/pause.rs` | `mosaico pause` / `mosaico unpause` handler |
 | `crates/mosaico/src/commands/banner.rs` | Shared ASCII logo used by `start` and `doctor` |
 | `crates/mosaico/src/commands/update.rs` | `mosaico update` handler |
 | `crates/mosaico/src/commands/debug/list.rs` | `mosaico debug list` handler |
@@ -33,7 +34,7 @@ dedicated handler module under `crates/mosaico/src/commands/`.
 
 - `Cli` -- top-level `clap::Parser` struct
 - `Commands` -- enum of all subcommands: `Init`, `Start`, `Stop`, `Status`,
-  `Doctor`, `Update`, `Action`, `Debug`, `Daemon`
+  `Doctor`, `Update`, `Action`, `Pause`, `Unpause`, `Debug`, `Daemon`
 - `ActionCommands` -- enum: `Focus { direction }`, `Move { direction }`,
   `Retile`, `ToggleMonocle`, `CloseFocused`, `GoToWorkspace { n }`,
   `SendToWorkspace { n }`
@@ -148,6 +149,26 @@ The self-replacement works by renaming the running `mosaico.exe` to
 `mosaico.exe.old` (Windows allows renaming but not overwriting a locked file),
 then writing the new binary in its place. The `.old` backup is cleaned up
 immediately or on the next daemon start.
+
+### `mosaico pause`
+
+Pauses all mosaico global hotkeys by unregistering them from the system. While
+paused, mosaico's key combinations are fully released to the OS and can be used
+by other applications. The `toggle-pause` hotkey (if configured) remains
+registered so you can resume without a terminal.
+
+```sh
+mosaico pause
+```
+
+### `mosaico unpause`
+
+Re-registers all hotkeys that were paused. Mosaico resumes normal hotkey
+handling immediately.
+
+```sh
+mosaico unpause
+```
 
 ### `mosaico daemon` (hidden)
 

--- a/docs/keyboard-bindings.md
+++ b/docs/keyboard-bindings.md
@@ -25,14 +25,17 @@ Keyboard binding handling spans two crates:
 
 - `Keybinding` -- fields: `action: Action`, `key: String`, `modifiers: Vec<Modifier>`
 - `Modifier` -- enum: `Alt`, `Shift`, `Ctrl`, `Win`
-- `HotkeyManager` -- fields: `hotkeys: Vec<Hotkey>`, `sender: Sender<Action>`
-- `Hotkey` (private) -- fields: `id: i32`, `action: Action`
+- `HotkeyManager` -- fields: `hotkeys: Vec<Hotkey>`, `sender: Sender<Action>`,
+  `paused: bool`, `pause_hotkey_id: Option<i32>`
+- `Hotkey` (private) -- fields: `id: i32`, `modifiers: HOT_KEY_MODIFIERS`,
+  `vk: u32`, `action: Action`
 
 ## Registration Flow
 
-1. **Config loading** -- `daemon_loop()` calls `config::load_keybindings()`,
-   which reads `~/.config/mosaico/keybindings.toml` or falls back to
-   `keybinding::defaults()`
+1. **Config loading** -- `daemon_loop()` calls `config::merge_missing_keybindings()`,
+   which reads `~/.config/mosaico/keybindings.toml`, appends any missing default
+   actions (new bindings added by future versions) to the file, then returns the
+   merged set. Falls back to `keybinding::defaults()` if the file is absent.
 
 2. **Pass to event loop** -- keybindings are passed to `event_loop::start()`
 
@@ -47,7 +50,9 @@ Keyboard binding handling spans two crates:
    - Always adds `MOD_NOREPEAT` to prevent key-repeat flooding
    - Calls `RegisterHotKey(None, id, modifiers, vk)` -- `None` HWND means
      registration on the current thread's message queue
-   - Stores a `Hotkey { id, action }` for later dispatch
+   - Stores a `Hotkey { id, modifiers, vk, action }` for later dispatch
+   - After the loop, scans for a `TogglePause` action and saves its ID as
+     `pause_hotkey_id` so it can be preserved during pause
 
 5. **Cleanup** -- `HotkeyManager` implements `Drop`, calling
    `UnregisterHotKey` for every registered hotkey on shutdown
@@ -65,6 +70,47 @@ User presses Alt+J
   -> Bridge thread wraps as DaemonMsg::Action
   -> TilingManager::handle_action()
 ```
+
+## Pause / Unpause
+
+Mosaico can temporarily release all its global hotkeys to the OS so another
+application can use those same key combinations.
+
+### How it works
+
+- **`toggle-pause` action** -- when triggered, sends a `WM_APP+2` message
+  (`WM_HOTKEY_PAUSE`) to the event loop thread via `PostThreadMessageW`.
+- **On pause** -- `HotkeyManager::pause()` calls `UnregisterHotKey` for every
+  hotkey *except* the `toggle-pause` binding (so you can always unpause).
+  Sets `paused = true`.
+- **On unpause** -- `HotkeyManager::unpause()` calls `RegisterHotKey` for every
+  previously unregistered hotkey. Sets `paused = false`.
+- **State mirroring** -- the daemon main thread tracks a `hotkeys_paused: bool`
+  local variable and passes it to the bar so the `paused` widget shows while
+  paused.
+- **CLI** -- `mosaico pause` / `mosaico unpause` send `PauseHotkeys` /
+  `UnpauseHotkeys` IPC commands. The daemon forwards them to the event loop
+  via the same `WM_HOTKEY_PAUSE` mechanism.
+
+### Lockout prevention
+
+The `toggle-pause` hotkey stays registered while paused. If no `toggle-pause`
+binding is configured, pausing via keyboard isn't possible, but `mosaico unpause`
+always works.
+
+### Configuration
+
+Add to `~/.config/mosaico/keybindings.toml`:
+
+```toml
+[[keybinding]]
+action = "toggle-pause"
+key = "P"
+modifiers = ["alt", "shift"]
+```
+
+Then restart the daemon. The status bar shows a red **PAUSED** indicator while
+hotkeys are suspended.
 
 ## Key Name Resolution
 
@@ -105,7 +151,8 @@ spatial motions plus workspace switching:
 | Alt + 1-8 | GoToWorkspace(1-8) |
 | Alt + Shift + 1-8 | SendToWorkspace(1-8) |
 
-The H/J/K/L keys follow vim conventions: H=left, J=down, K=up, L=right.
+The H/J/K/L keys follow vim conventions: H=left, J=down, K=up, L=right. The
+`toggle-pause` action is not bound by default; add it manually.
 Focus navigates spatially; Move swaps or transfers windows in the same
 direction. Alt+<number> switches to workspace N on the focused monitor;
 Alt+Shift+<number> sends the focused window to workspace N. Alt+N cycles

--- a/docs/status-bar.md
+++ b/docs/status-bar.md
@@ -82,8 +82,14 @@ pixel buffer using geometry helpers (`in_rounded_rect`, `is_border_pixel`).
 | `cpu` | CPU usage percentage via `GetSystemTimes` delta tracking | -- |
 | `update` | Update notification when newer version is available | -- |
 | `media` | Currently playing track via GSMTC | `max_length` (default 40) |
+| `paused` | Indicator shown when mosaico hotkeys are paused | `color` (default `"red"`) |
 
 Each widget can be independently enabled/disabled and assigned a custom icon.
+
+The `paused` widget is auto-hidden when hotkeys are not paused (`should_skip()`
+returns `true` unless `state.paused`). It is included in the default bar config
+and added automatically to existing `bar.toml` files via the widget auto-merge
+mechanism (see below).
 
 ### Active Window Icon
 
@@ -129,9 +135,19 @@ The `BarState` struct provides the data each widget needs:
 - `cpu_usage` -- current CPU percentage (from `CpuTracker`)
 - `update_text` -- update notification string (empty if up to date)
 - `media_text` -- formatted media info, e.g. "Artist - Title" (empty if nothing playing)
+- `paused` -- whether mosaico hotkeys are currently paused
 
 `TilingManager::bar_states()` produces a `Vec<BarState>` snapshot for all
 monitors on each render cycle.
+
+## Widget Auto-Merge
+
+On daemon startup, `merge_missing_bar_widgets()` compares the widget types
+present in the user's `bar.toml` against the built-in defaults. Any widget
+type not already present is appended to the file automatically, so new widgets
+added in future versions are picked up without requiring users to edit their
+config. The comparison uses `std::mem::discriminant` (enum variant identity)
+so a user who intentionally removes a widget type will not have it re-added.
 
 ## Bar Manager
 

--- a/website/src/guide/cli.md
+++ b/website/src/guide/cli.md
@@ -107,6 +107,21 @@ mosaico action send-to-workspace <1-8>
 These are the same actions triggered by keyboard shortcuts, useful for
 scripting or integration with other tools.
 
+## `mosaico pause` / `mosaico unpause`
+
+Temporarily suspends all mosaico global hotkeys so another application can use
+those key combinations, then restores them.
+
+```sh
+mosaico pause     # Unregister all hotkeys (releases them to the OS)
+mosaico unpause   # Re-register all hotkeys
+```
+
+While paused, the status bar shows a red **PAUSED** indicator. You can also
+toggle pause from the keyboard by binding the `toggle-pause` action — the
+toggle hotkey remains registered while paused so you can resume without opening
+a terminal. See [Keyboard Bindings](keybindings.md#pause--unpause) for setup.
+
 ## `mosaico debug list`
 
 Displays a formatted table of all visible windows showing:

--- a/website/src/guide/keybindings.md
+++ b/website/src/guide/keybindings.md
@@ -60,6 +60,7 @@ modifiers = ["alt", "shift"]
 | `close-focused` | Close the focused window |
 | `goto-workspace-N` | Switch to workspace N (1-8) |
 | `send-to-workspace-N` | Send focused window to workspace N (1-8) |
+| `toggle-pause` | Toggle hotkey pause on/off |
 
 ### Modifiers
 
@@ -82,6 +83,37 @@ modifiers = ["alt", "shift"]
 | Punctuation | `Minus`, `Plus`, `Comma`, `Period` |
 
 Unknown key names are skipped with a log message.
+
+## Pause / Unpause
+
+If another application uses the same global shortcuts as mosaico, you can
+temporarily release mosaico's hotkeys so that application can receive them:
+
+```toml
+[[keybinding]]
+action = "toggle-pause"
+key = "P"
+modifiers = ["alt", "shift"]
+```
+
+Press `Alt+Shift+P` to pause — the status bar shows a red **PAUSED** indicator.
+Press it again to resume. You can also use the CLI:
+
+```sh
+mosaico pause
+mosaico unpause
+```
+
+The `toggle-pause` hotkey stays registered while paused so you can always
+resume from the keyboard without opening a terminal.
+
+## Auto-merge
+
+On each daemon start, any default keybinding actions not present in your
+`keybindings.toml` are automatically appended to the file. This ensures you
+pick up new shortcuts added in future versions without overwriting any of your
+customizations. Actions you've already bound (even to different keys) are
+never touched.
 
 ## Reloading
 

--- a/website/src/guide/status-bar.md
+++ b/website/src/guide/status-bar.md
@@ -66,6 +66,7 @@ Widgets are placed in `[[left]]`, `[[center]]`, or `[[right]]` arrays.
 | `cpu` | CPU usage percentage | -- |
 | `update` | Update indicator | -- |
 | `media` | Currently playing track | `max_length` |
+| `paused` | Shown (in red) when hotkeys are paused | `color` |
 
 The `active_window` widget displays the application icon of the currently
 focused window. It extracts the icon from the running process and renders
@@ -118,6 +119,11 @@ type = "ram"
 type = "date"
 format = "%a %d %b"
 ```
+
+The `paused` widget is auto-hidden when hotkeys are active and shown in red
+when they are paused. It is included in the default config and is added
+automatically to existing `bar.toml` files on daemon startup (along with any
+other new default widgets from future versions).
 
 ## Work Area
 


### PR DESCRIPTION
## Summary

- **Pause/unpause hotkeys** — new `toggle-pause` keybinding action (Alt+Shift+P by default) that unregisters all global hotkeys except itself so other apps can use the same combos, and re-registers them on the next press. Also adds `mosaico pause` / `mosaico unpause` CLI subcommands. A new `Paused` bar widget renders a red "PAUSED" pill while hotkeys are released.
- **Config auto-merge** — on startup the daemon compares user keybindings and bar widget configs against built-in defaults and appends any missing entries, so new defaults from future versions are picked up without overwriting customizations.
- **Hide-to-tray fix** — switch the `Hidden` event guard from `is_valid()` to `is_visible()` so Electron apps (Podman Desktop, Microsoft Teams) that hide to the tray via `SW_HIDE` are correctly unmanaged instead of leaving phantom slots in the layout. When the focused window is removed, promote a sibling on the active workspace so the border indicator stays visible.
- **Binary size** — release profile now uses `opt-level = "z"` and `panic = "abort"` (2.3MB → 1.2MB).
- **Docs** — cli.md, keyboard-bindings.md, status-bar.md, and the website guide all updated for the new features.

## Test plan

- [ ] Verify `Alt+Shift+P` toggles pause; confirm other mosaico hotkeys stop working while paused and resume on the next press
- [ ] Verify `mosaico pause` / `mosaico unpause` CLI subcommands behave the same as the hotkey
- [ ] Confirm the bar shows the red "PAUSED" pill while paused and hides it otherwise
- [ ] Delete a widget entry from `bar.toml` and restart — confirm it is re-added by auto-merge; modify an existing entry and confirm customizations are preserved
- [ ] Hide Microsoft Teams / Podman Desktop to tray and confirm the slot is reclaimed and neighbor windows resize
- [ ] With the focused window closed, confirm a sibling on the active workspace receives focus and the border indicator remains visible
- [ ] Build release binary and confirm size reduction