### PR TITLE
fix: preserve active layout across config reload + fix uneven inner/outer gap

### DIFF
--- a/crates/mosaico-core/src/layout/tests.rs
+++ b/crates/mosaico-core/src/layout/tests.rs
@@ -194,3 +194,50 @@ fn three_col_empty_returns_empty() {
     let area = Rect::new(0, 0, 1920, 1080);
     assert!(layout.apply(&[], &area).is_empty());
 }
+
+#[test]
+fn three_col_inner_gap_matches_outer_padding() {
+    let gap = 8;
+    let layout = ThreeColumnLayout { gap, ratio: 0.5 };
+    let area = Rect::new(0, 0, 1920, 1080);
+    let result = layout.apply(&[1, 2, 3, 4, 5], &area);
+
+    // result order: master, left[0], left[1], right[0], right[1]
+    let master = &result[0].1;
+    let left0 = &result[1].1;
+    let left1 = &result[2].1;
+    let right0 = &result[3].1;
+    let right1 = &result[4].1;
+
+    // Outer padding: left column's left edge sits `gap` from the area left.
+    assert_eq!(left0.x - area.x, gap);
+    // Outer padding: right column's right edge sits `gap` from the area right.
+    assert_eq!(area.x + area.width - (right0.x + right0.width), gap);
+    // Inner column gaps (left↔master and master↔right) equal `gap`.
+    assert_eq!(master.x - (left0.x + left0.width), gap);
+    assert_eq!(right0.x - (master.x + master.width), gap);
+    // Inner stack gaps (between slots within a side column) equal `gap`.
+    assert_eq!(left1.y - (left0.y + left0.height), gap);
+    assert_eq!(right1.y - (right0.y + right0.height), gap);
+}
+
+#[test]
+fn vstack_inner_gap_matches_outer_padding() {
+    let gap = 8;
+    let layout = VerticalStackLayout { gap, ratio: 0.5 };
+    let area = Rect::new(0, 0, 1920, 1080);
+    let result = layout.apply(&[1, 2, 3], &area);
+
+    let master = &result[0].1;
+    let stack0 = &result[1].1;
+    let stack1 = &result[2].1;
+
+    // Outer padding on all four sides.
+    assert_eq!(master.x - area.x, gap);
+    assert_eq!(master.y - area.y, gap);
+    assert_eq!(area.x + area.width - (stack0.x + stack0.width), gap);
+    // Inner master↔stack horizontal gap.
+    assert_eq!(stack0.x - (master.x + master.width), gap);
+    // Inner stack slot vertical gap.
+    assert_eq!(stack1.y - (stack0.y + stack0.height), gap);
+}

--- a/crates/mosaico-core/src/layout/three_column.rs
+++ b/crates/mosaico-core/src/layout/three_column.rs
@@ -27,22 +27,24 @@ impl Default for ThreeColumnLayout {
 }
 
 impl ThreeColumnLayout {
-    /// Fills a vertical stack of windows into the given area.
+    /// Fills a vertical stack of windows into the given area, separating
+    /// adjacent slots by a full `gap` so the inner spacing matches the
+    /// outer padding.
     fn fill_stack(
         &self,
         handles: &[usize],
         area: &Rect,
-        half: i32,
+        gap: i32,
         results: &mut Vec<(usize, Rect)>,
     ) {
         if handles.is_empty() {
             return;
         }
         let count = handles.len() as i32;
-        let slot_h = (area.height - half * (count - 1)) / count;
+        let slot_h = (area.height - gap * (count - 1)) / count;
 
         for (i, &hwnd) in handles.iter().enumerate() {
-            let sy = area.y + (i as i32) * (slot_h + half);
+            let sy = area.y + (i as i32) * (slot_h + gap);
             let sh = if i as i32 == count - 1 {
                 (area.y + area.height - sy).max(1)
             } else {
@@ -86,11 +88,12 @@ impl Layout for ThreeColumnLayout {
         }
 
         // 3+ windows: master in center, extras alternate left/right.
+        // Reserve a full `gap` on each side of the master (2 × gap total).
         let master_w = (padded.width as f64 * self.ratio) as i32;
-        let side_w = (padded.width - master_w - half * 2) / 2;
+        let side_w = (padded.width - master_w - self.gap * 2) / 2;
         let left_x = padded.x;
-        let master_x = padded.x + side_w + half;
-        let right_x = master_x + master_w + half;
+        let master_x = padded.x + side_w + self.gap;
+        let right_x = master_x + master_w + self.gap;
         let right_w = (padded.x + padded.width - right_x).max(1);
 
         let mut results = Vec::with_capacity(handles.len());
@@ -111,10 +114,10 @@ impl Layout for ThreeColumnLayout {
         }
 
         let left_area = Rect::new(left_x, padded.y, side_w.max(1), padded.height);
-        self.fill_stack(&left_handles, &left_area, half, &mut results);
+        self.fill_stack(&left_handles, &left_area, self.gap, &mut results);
 
         let right_area = Rect::new(right_x, padded.y, right_w, padded.height);
-        self.fill_stack(&right_handles, &right_area, half, &mut results);
+        self.fill_stack(&right_handles, &right_area, self.gap, &mut results);
 
         results
     }

--- a/crates/mosaico-core/src/layout/vertical_stack.rs
+++ b/crates/mosaico-core/src/layout/vertical_stack.rs
@@ -51,13 +51,15 @@ impl Layout for VerticalStackLayout {
         let stack_x = padded.x + master_w + half;
         let stack_w = (padded.width - master_w - half).max(1);
         let stack_count = handles.len() - 1;
-        let slot_h = (padded.height - half * (stack_count as i32 - 1)) / stack_count as i32;
+        // Stack slots are separated by a full `gap` so inner spacing matches
+        // the outer padding.
+        let slot_h = (padded.height - self.gap * (stack_count as i32 - 1)) / stack_count as i32;
 
         let mut results = Vec::with_capacity(handles.len());
         results.push((handles[0], master));
 
         for (i, &hwnd) in handles[1..].iter().enumerate() {
-            let y = padded.y + (i as i32) * (slot_h + half);
+            let y = padded.y + (i as i32) * (slot_h + self.gap);
             let h = if i == stack_count - 1 {
                 (padded.y + padded.height - y).max(1)
             } else {

--- a/crates/mosaico-windows/src/tiling/lifecycle.rs
+++ b/crates/mosaico-windows/src/tiling/lifecycle.rs
@@ -48,22 +48,15 @@ impl TilingManager {
     }
 
     /// Applies a new layout and border config, then retiles all windows.
+    ///
+    /// Per-workspace `layout_kind` is intentionally not touched: after
+    /// startup the active layout is runtime state owned by `cycle-layout`
+    /// and explicit `set-layout` actions. Config reload must not silently
+    /// undo those choices when the user tweaks unrelated settings like gap
+    /// or borders. Changes to `[layout.workspaces]` take effect on restart.
     pub fn reload_config(&mut self, config: &mosaico_core::config::Config) {
         self.layout_gap = config.layout.gap;
         self.layout_ratio = config.layout.ratio;
-        // Reset workspace layouts to config values.
-        for mon in &mut self.monitors {
-            for (i, ws) in mon.workspaces.iter_mut().enumerate() {
-                let ws_num = (i + 1) as u8;
-                let kind = config
-                    .layout
-                    .workspaces
-                    .get(&ws_num)
-                    .copied()
-                    .unwrap_or(config.layout.default);
-                ws.set_layout_kind(kind);
-            }
-        }
         self.hiding = config.layout.hiding;
         self.border_config = config.borders.clone();
         self.mouse_follows_focus = config.mouse.follows_focus;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,11 +223,14 @@ detected and applied while the daemon is running. The config file watcher
 (see [daemon.md](daemon.md)) polls for modification time changes every
 2 seconds.
 
-- **config.toml**: layout algorithm, gap/ratio, hiding behaviour, border
-  settings, and theme are reloaded. The tiling manager calls `reload_config()` which
-  updates the `BspLayout`, hiding strategy, and `BorderConfig`, then retiles
-  all windows. If the theme changed, bar colors are re-resolved. Hiding
-  changes take effect on the next workspace switch.
+- **config.toml**: gap/ratio, hiding behaviour, border settings, and theme
+  are reloaded. The tiling manager calls `reload_config()` which updates the
+  layout gap/ratio, hiding strategy, and `BorderConfig`, then retiles all
+  windows. If the theme changed, bar colors are re-resolved. Hiding changes
+  take effect on the next workspace switch. Per-workspace layout overrides
+  (`[layout.workspaces]` and `layout.default`) are applied at startup only —
+  reloading does not override the active layout chosen via `cycle-layout`
+  or `set-layout`; restart the daemon to pick up changes.
 - **rules.toml**: window rules are replaced via `reload_rules()`. New rules
   apply to newly created windows; existing managed windows are not re-evaluated.
 - **bar.toml**: the `BarManager` is recreated with `reload()`, colors are


### PR DESCRIPTION
## Summary

Two related gap/layout fixes.

### Preserve active layout across config reload

- `reload_config()` in `tiling/lifecycle.rs` was unconditionally resetting every workspace's `layout_kind` to the value in `[layout.workspaces]` / `layout.default` on every hot-reload. Editing an unrelated setting like `gap` while on `ThreeColumn` would bounce the workspace back to `Bsp`, silently undoing any `cycle-layout` choice.
- Fix: treat per-workspace layout config as startup-only state. After startup the active layout is owned by runtime actions (`cycle-layout`, `set-layout`) and is not touched on reload. Updates to `[layout.workspaces]` now take effect on daemon restart.
- `docs/configuration.md` Hot-Reload section updated accordingly.

### Inner window gap == outer padding

- Outer padding from the monitor edge used the full `gap`, but inner spacing between adjacent windows in `ThreeColumn` (3+ windows) and inside `VerticalStack`'s stack only used `gap/2`. Visually, windows sat farther from the monitor edge than from each other.
- `ThreeColumn` (3+ windows): reserve a full `gap` on each side of the master column so left-master and master-right both equal `gap`.
- `ThreeColumn::fill_stack` and `VerticalStack` stack-inner: step slots by `slot_h + gap` so inner stack spacing equals `gap`.
- `BspLayout` was already correct (each side of a split takes `gap/2`, summing to a full `gap`) and is unchanged.
- Added two regression tests pinning `inner_gap == outer_padding` for `ThreeColumn` (5 windows) and `VerticalStack` (3 windows).

## Test plan

- [ ] Start daemon, cycle to `ThreeColumn`, edit `gap` in `config.toml`, save — workspace stays on `ThreeColumn` with new gap applied
- [ ] `gap`, `ratio`, `hiding`, border settings, and theme still hot-reload
- [ ] Change `[layout.workspaces].1` in config, save, and confirm it does NOT take effect on reload; restart daemon and confirm it does
- [ ] With 3+ windows in `ThreeColumn` and `gap=8`, measure spacing — gap between columns and between monitor edge should both be 8px
- [ ] With 3+ windows in `VerticalStack` and `gap=8`, measure spacing — gap between stack items and between monitor edge should both be 8px
- [ ] `cycle-layout` / `set-layout` actions still work
