### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "mosaico-core",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico-windows"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "mosaico-core",
  "serde_json",

--- a/crates/mosaico-core/Cargo.toml
+++ b/crates/mosaico-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Platform-agnostic core types and traits for Mosaico"
 license = "MIT"

--- a/crates/mosaico-windows/Cargo.toml
+++ b/crates/mosaico-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico-windows"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Windows platform implementation for Mosaico"
 license = "MIT"

--- a/crates/mosaico/Cargo.toml
+++ b/crates/mosaico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "A cross-platform tiling window manager"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump `0.7.0` → `0.8.0` across the three workspace crates, ahead of tagging a new release.

## Release notes (since v0.7.0)

### Features
- Pause/unpause hotkeys with Alt+Shift+P, `mosaico pause` / `mosaico unpause` CLI, and a red "PAUSED" bar widget (#2)
- Config auto-merge on startup — new default keybindings and bar widgets are appended to user config without clobbering customizations (#2)

### Fixes
- Electron apps that hide to the tray (Podman Desktop, Teams) are now correctly unmanaged instead of leaving phantom slots (#2)
- Focused window removal promotes a sibling so the border indicator stays visible (#2)
- Config reload no longer resets the active layout — `cycle-layout` choices survive edits to `gap`, `ratio`, etc. (#3)
- Inner window gap in `ThreeColumn` and `VerticalStack` now matches outer padding (both equal `gap`, previously inner was `gap/2`) (#3)

### Internal
- Release profile: `opt-level = "z"` + `panic = "abort"` (2.3 MB → 1.2 MB)