### PR TITLE
fix: add Alt+Shift+P → toggle-pause to default keybindings

### DIFF
--- a/crates/mosaico-core/src/config/keybinding.rs
+++ b/crates/mosaico-core/src/config/keybinding.rs
@@ -35,6 +35,7 @@ pub enum Modifier {
 /// Workspaces: Alt + 1..8 (switch), Alt + Shift + 1..8 (send)
 /// Monocle: Alt + T
 /// Retile: Alt + Shift + R
+/// Pause hotkeys: Alt + Shift + P
 pub fn defaults() -> Vec<Keybinding> {
     use Modifier::{Alt, Shift};
 
@@ -58,6 +59,8 @@ pub fn defaults() -> Vec<Keybinding> {
         bind(Action::MinimizeFocused, "M", &[Alt]),
         // Cycle layout
         bind(Action::CycleLayout, "N", &[Alt]),
+        // Pause/unpause all hotkeys
+        bind(Action::TogglePause, "P", &[Alt, Shift]),
     ];
 
     // Workspaces: Alt+1..8 to switch, Alt+Shift+1..8 to send

--- a/crates/mosaico-core/src/config/keybindings_focus_move.rs
+++ b/crates/mosaico-core/src/config/keybindings_focus_move.rs
@@ -69,5 +69,11 @@ modifiers = ["alt"]
 action = "cycle-layout"
 key = "N"
 modifiers = ["alt"]
+
+# Pause/unpause all hotkeys: Alt + Shift + P
+[[keybinding]]
+action = "toggle-pause"
+key = "P"
+modifiers = ["alt", "shift"]
 "##
 }


### PR DESCRIPTION
## Summary

`Action::TogglePause` was wired up end-to-end in #2 (action enum, IPC command, hotkey pause/unpause logic, bar widget, docs) but the default `Alt+Shift+P → toggle-pause` keybinding was never added to `keybinding::defaults()`. As a result:

- **New installs**: generated `keybindings.toml` doesn't include `toggle-pause`.
- **Existing users**: the auto-merge added in #2 iterates over `defaults()` looking for missing entries and finds none for `TogglePause`, so the binding is never appended to their file.

Net effect: the announced `Alt+Shift+P` hotkey does nothing unless a user hand-adds the `[[keybinding]]` block themselves.

## Fix

- Add `bind(Action::TogglePause, "P", &[Alt, Shift])` to `keybinding::defaults()`.
- Add the corresponding `[[keybinding]]` entry to the built-in keybindings template (`keybindings_focus_move.rs`) so generated files include it.

Existing users will get the binding appended to their `keybindings.toml` automatically on the next daemon start via `merge_missing_keybindings()`.

The existing `keybindings_template_matches_defaults` test (which asserts `file.keybinding.len() == defaults.len()`) continues to pass because both lists grow by one.

## Suggested release flow

This should land before tagging `v0.8.0` so the release doesn't ship an advertised feature that's unreachable out of the box. Merge this, then update/recut PR #4 so the version bump commit sits on top of this fix, then tag.

## Test plan

- [ ] Fresh install: delete `keybindings.toml`, start daemon, confirm the regenerated file contains a `toggle-pause` entry with `key = "P"` and `modifiers = ["alt", "shift"]`
- [ ] Existing install: with a `keybindings.toml` missing the `toggle-pause` entry, start daemon, confirm the entry is appended and the info log reports 1 missing binding added
- [ ] `Alt+Shift+P` toggles pause and the red `PAUSED` bar widget appears/disappears
- [ ] Pressing `Alt+Shift+P` again (or any other hotkey after resume) continues to work
