### PR TITLE
fix: pick geometrically nearest window when crossing monitors

### DIFF
--- a/crates/mosaico-core/src/spatial.rs
+++ b/crates/mosaico-core/src/spatial.rs
@@ -70,20 +70,35 @@ pub fn find_neighbor(
 
 /// Finds the best window to focus when entering a monitor.
 ///
-/// Picks the topmost window first, breaking ties by the edge closest
-/// to the direction of travel (leftmost when entering from the left,
-/// rightmost when entering from the right).
+/// Picks the window geometrically nearest to the edge being crossed
+/// (leftmost for Direction::Right, rightmost for Direction::Left,
+/// topmost for Direction::Down, bottommost for Direction::Up). Ties
+/// on that axis are broken by the perpendicular axis, preferring
+/// topmost/leftmost.
 pub fn find_entry(positions: &[(usize, Rect)], direction: Direction) -> Option<usize> {
+    let horizontal = matches!(direction, Direction::Left | Direction::Right);
     let positive = matches!(direction, Direction::Right | Direction::Down);
     positions
         .iter()
         .max_by_key(|(_, r)| {
-            let x = if positive {
-                -r.center_x()
+            let (primary_axis, perp_axis) = if horizontal {
+                (r.center_x(), r.center_y())
             } else {
-                r.center_x()
+                (r.center_y(), r.center_x())
             };
-            (-r.center_y(), x)
+            // Primary: window nearest the crossing edge. For positive
+            // directions (Right, Down) we enter from the low end of the
+            // axis, so we want the SMALLEST coordinate → negate to fit
+            // max_by_key. For negative directions we want the largest
+            // coordinate directly.
+            let primary = if positive {
+                -primary_axis
+            } else {
+                primary_axis
+            };
+            // Tiebreaker: prefer topmost (smallest y) for horizontal
+            // crossings, leftmost (smallest x) for vertical crossings.
+            (primary, -perp_axis)
         })
         .map(|(h, _)| *h)
 }
@@ -289,20 +304,50 @@ mod tests {
     #[test]
     fn entry_from_left_three_windows() {
         let pos = three_windows();
-        // Topmost first → Win 2 (center_y=270).
-        assert_eq!(find_entry(&pos, Direction::Right), Some(2));
+        // Entering from the left → leftmost wins → Win 1 (the full-height
+        // master on the left half), not Win 2 (top-right quadrant).
+        assert_eq!(find_entry(&pos, Direction::Right), Some(1));
     }
 
     #[test]
     fn entry_from_right_three_windows() {
         let pos = three_windows();
+        // Entering from the right → rightmost wins. Win 2 (top-right) and
+        // Win 3 (bot-right) share the rightmost center_x; topmost
+        // tiebreaker picks Win 2.
         assert_eq!(find_entry(&pos, Direction::Left), Some(2));
     }
 
     #[test]
     fn entry_from_right_four_windows() {
         let pos = four_windows();
-        assert_eq!(find_entry(&pos, Direction::Left), Some(2));
+        // Entering from the right → rightmost wins → Win 4 (bot-right-R
+        // at center_x=1680), not Win 2 (top-right at center_x=1440).
+        assert_eq!(find_entry(&pos, Direction::Left), Some(4));
+    }
+
+    #[test]
+    fn entry_from_left_two_windows_vstack_like() {
+        // Master (left, full height) + single stack window (right, full
+        // height) — same as BSP/VStack with 2 windows.
+        let pos = vec![
+            (10, Rect::new(0, 0, 960, 1080)),
+            (20, Rect::new(960, 0, 960, 1080)),
+        ];
+        assert_eq!(find_entry(&pos, Direction::Right), Some(10));
+    }
+
+    #[test]
+    fn entry_from_left_vstack_three_windows() {
+        // VStack 3 windows: master on left (full height), two stack slots
+        // on the right. Entering from the left must land on the master,
+        // not on the topmost stack slot.
+        let pos = vec![
+            (1, Rect::new(0, 0, 960, 1080)),    // master
+            (2, Rect::new(960, 0, 960, 540)),   // stack top
+            (3, Rect::new(960, 540, 960, 540)), // stack bot
+        ];
+        assert_eq!(find_entry(&pos, Direction::Right), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When navigating `Alt+L` from a window on monitor 1 into monitor 2 (which was using BSP or VStack), focus skipped the left-side master window and landed on the top-right stack slot instead. This is the third pre-0.8.0 fix.

## Root cause

`find_entry` in `crates/mosaico-core/src/spatial.rs` was sorting entry candidates with the key `(-center_y, direction_x)`, i.e. **topmost was the primary criterion and the direction-edge axis was only a tiebreaker**. For a BSP or VStack with 3+ windows, the stack slots on the right have smaller `center_y` than the full-height master on the left, so they won the "topmost" sort and focus jumped past the master.

ThreeColumn "worked" by accident: with 3 windows its columns all span full height, so all `center_y` values are equal, the primary sort is a tie, and the tiebreaker (direction-edge) picked the correct leftmost window.

## Fix

Swap the sort key so the **direction axis is primary** and the perpendicular axis is the tiebreaker:

- `Direction::Right` → leftmost wins, tie broken by topmost
- `Direction::Left` → rightmost wins, tie broken by topmost
- `Direction::Down` → topmost wins, tie broken by leftmost
- `Direction::Up` → bottommost wins, tie broken by leftmost

## Test changes

Two existing tests codified the buggy "topmost first" behavior and have been updated to assert the correct expectation:

- `entry_from_left_three_windows`: was `Some(2)` (top-right), now `Some(1)` (left master)
- `entry_from_right_four_windows`: was `Some(2)` (top-right), now `Some(4)` (bottom-right-R, the rightmost)

Two new regression tests added:

- `entry_from_left_two_windows_vstack_like` — 2-window BSP/VStack-like layout
- `entry_from_left_vstack_three_windows` — 3-window VStack layout (master left, stack right)

## Test plan

- [ ] M1 + M2 side by side, M2 in BSP with 3+ windows: `Alt+L` from M1 lands on M2's master, not the top-right stack slot
- [ ] Same setup with VStack instead of BSP: still lands on master
- [ ] Same with 3Col (3+ windows): behavior unchanged, lands on left column
- [ ] Reverse direction (`Alt+H` from M2 to M1): lands on the rightmost window of M1 regardless of layout
