### PR TITLE
feat(workspaces): add per-monitor and global workspace modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,18 @@ A fast, configurable tiling window manager for Windows, written in Rust.
 
 ## Features
 
-- Automatic tiling with configurable layouts (BSP, monocle)
+- Automatic tiling with three layout algorithms (BSP, VerticalStack,
+  ThreeColumn) cyclable per workspace at runtime
+- Up to 8 workspaces with per-monitor (default) or global switching, the
+  latter mirroring Windows virtual desktops
+- Monocle mode for distraction-free single-window focus
 - Vim-style keybindings out of the box
 - Hot-reload for config and window rules — no restart needed
+- Pause/unpause all hotkeys with `Alt + Shift + P` for full-screen apps
 - Per-app rules to exclude windows from tiling
 - Colored window borders to identify the focused window
-- Status bar with CPU, RAM, and active window widgets
-- Multi-monitor support
+- Status bar with workspace indicators, clock, CPU, RAM, and more
+- Multi-monitor support with cross-monitor focus and window movement
 - One-line install, zero dependencies
 - Built-in `doctor` command to diagnose setup issues
 
@@ -49,17 +54,23 @@ mosaico --help             # Show all available commands
 ### Actions
 
 ```sh
-mosaico action focus left      # Focus window to the left
-mosaico action focus right     # Focus window to the right
-mosaico action focus up        # Focus window above
-mosaico action focus down      # Focus window below
-mosaico action move left       # Move window to the left
-mosaico action move right      # Move window to the right
-mosaico action move up         # Move window up
-mosaico action move down       # Move window down
-mosaico action retile          # Re-apply the current layout
-mosaico action toggle-monocle  # Toggle monocle mode
-mosaico action close-focused   # Close the focused window
+mosaico action focus left         # Focus window to the left
+mosaico action focus right        # Focus window to the right
+mosaico action focus up           # Focus window above
+mosaico action focus down         # Focus window below
+mosaico action move left          # Move window to the left
+mosaico action move right         # Move window to the right
+mosaico action move up            # Move window up
+mosaico action move down          # Move window down
+mosaico action retile             # Re-apply the current layout
+mosaico action toggle-monocle     # Toggle monocle mode
+mosaico action cycle-layout       # Cycle BSP / VerticalStack / ThreeColumn
+mosaico action close-focused      # Close the focused window
+mosaico action minimize-focused   # Minimize the focused window
+mosaico action goto-workspace-3   # Switch to workspace 3 (1-8)
+mosaico action send-to-workspace-5  # Send focused window to workspace 5 (1-8)
+mosaico pause                     # Pause all hotkeys (also Alt + Shift + P)
+mosaico unpause                   # Resume all hotkeys
 ```
 
 ### Debugging
@@ -75,30 +86,37 @@ Configuration files live in `~/.config/mosaico/`:
 
 | File | Purpose |
 |------|---------|
-| `config.toml` | Layout (gap, ratio) and border settings |
+| `config.toml` | Layout (gap, ratio), workspace mode, borders, theme, logging |
 | `keybindings.toml` | Hotkey mappings (vim-style by default) |
-| `rules.toml` | Window rules for excluding apps from tiling |
+| `bar.toml` | Status bar widgets and colors |
+| `rules.toml` | Community window rules (auto-downloaded) |
+| `user-rules.toml` | Personal rule overrides; take priority over `rules.toml` |
 
-Changes to `config.toml` and `rules.toml` are hot-reloaded automatically.
-Keybinding changes require a daemon restart.
+Changes to `config.toml`, `bar.toml`, and `user-rules.toml` are
+hot-reloaded automatically. Keybinding changes require a daemon restart.
 
 Run `mosaico init` to create the default configuration files.
 
 ### Default keybindings
 
-| Shortcut        | Action         |
-|-----------------|----------------|
-| Alt + H         | Focus left     |
-| Alt + J         | Focus down     |
-| Alt + K         | Focus up       |
-| Alt + L         | Focus right    |
-| Alt + Shift + H | Move left      |
-| Alt + Shift + J | Move down      |
-| Alt + Shift + K | Move up        |
-| Alt + Shift + L | Move right     |
-| Alt + Shift + R | Retile         |
-| Alt + T         | Toggle monocle |
-| Alt + Q         | Close focused  |
+| Shortcut             | Action                            |
+|----------------------|-----------------------------------|
+| Alt + H              | Focus left                        |
+| Alt + J              | Focus down                        |
+| Alt + K              | Focus up                          |
+| Alt + L              | Focus right                       |
+| Alt + Shift + H      | Move left                         |
+| Alt + Shift + J      | Move down                         |
+| Alt + Shift + K      | Move up                           |
+| Alt + Shift + L      | Move right                        |
+| Alt + Shift + R      | Retile                            |
+| Alt + T              | Toggle monocle                    |
+| Alt + N              | Cycle layout (BSP / VStack / 3Col) |
+| Alt + Q              | Close focused                     |
+| Alt + M              | Minimize focused                  |
+| Alt + 1 .. Alt + 8       | Switch to workspace 1-8           |
+| Alt + Shift + 1 .. Alt + Shift + 8 | Send focused window to workspace 1-8 |
+| Alt + Shift + P      | Pause / unpause all hotkeys       |
 
 ### Logging
 

--- a/crates/mosaico-core/Cargo.toml
+++ b/crates/mosaico-core/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+toml_edit = "0.22"
 
 [lints]
 workspace = true

--- a/crates/mosaico-core/src/config/loader.rs
+++ b/crates/mosaico-core/src/config/loader.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::bar::BarConfig;
 use super::keybinding;
@@ -40,6 +40,10 @@ pub fn bar_path() -> Option<PathBuf> {
 /// Returns `Ok(Config)` on success, or an error string describing
 /// what went wrong (IO error, parse error, etc.).
 ///
+/// If a legacy `[layout.workspaces]` section is detected, the file is
+/// backed up and rewritten in place to the new `[workspaces.layouts]`
+/// shape before parsing.
+///
 /// # Errors
 ///
 /// Returns `Err` if the config path cannot be determined, the file
@@ -47,10 +51,107 @@ pub fn bar_path() -> Option<PathBuf> {
 pub fn try_load() -> Result<Config, String> {
     let path = config_path().ok_or("could not determine config path")?;
     let content = std::fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+
+    let content = match migrate_config_if_needed(&path, &content)? {
+        Some(rewritten) => rewritten,
+        None => content,
+    };
+
     let mut config: Config =
         toml::from_str(&content).map_err(|e| format!("{}: {e}", path.display()))?;
     config.validate();
     Ok(config)
+}
+
+/// Migrates a legacy `[layout.workspaces]` section to `[workspaces.layouts]`.
+///
+/// On detection: backs up the original file (aborting if the backup write
+/// fails), rewrites the config in place using `toml_edit` so comments and
+/// formatting survive, and returns the new content for the caller to parse.
+///
+/// Returns `Ok(None)` when no migration was needed (no legacy section).
+fn migrate_config_if_needed(path: &Path, content: &str) -> Result<Option<String>, String> {
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+
+    let has_legacy = doc
+        .get("layout")
+        .and_then(|t| t.as_table())
+        .is_some_and(|t| t.contains_key("workspaces"));
+
+    if !has_legacy {
+        return Ok(None);
+    }
+
+    // Back up first -- abort migration if backup fails so we never mutate
+    // without a safety net.
+    let backup = backup_path(path);
+    std::fs::copy(path, &backup).map_err(|e| {
+        format!(
+            "could not back up {} to {}: {e}",
+            path.display(),
+            backup.display()
+        )
+    })?;
+
+    // Pull [layout.workspaces] out and place it under [workspaces.layouts].
+    let legacy = doc
+        .get_mut("layout")
+        .and_then(|t| t.as_table_mut())
+        .and_then(|t| t.remove("workspaces"));
+
+    if let Some(legacy_item) = legacy {
+        if doc.get("workspaces").is_none() {
+            doc.insert(
+                "workspaces",
+                toml_edit::Item::Table(toml_edit::Table::new()),
+            );
+        }
+        // If the user already has [workspaces.layouts], keep it and drop
+        // the legacy section. Otherwise install the legacy values there.
+        let workspaces = doc
+            .get_mut("workspaces")
+            .and_then(|t| t.as_table_mut())
+            .ok_or_else(|| {
+                format!(
+                    "{}: [workspaces] is not a table -- cannot migrate",
+                    path.display()
+                )
+            })?;
+        if !workspaces.contains_key("layouts") {
+            workspaces.insert("layouts", legacy_item);
+        }
+    }
+
+    let new_content = doc.to_string();
+    std::fs::write(path, &new_content)
+        .map_err(|e| format!("could not write migrated config to {}: {e}", path.display()))?;
+
+    eprintln!(
+        "Info: migrated [layout.workspaces] -> [workspaces.layouts]. Backup saved at {}",
+        backup.display()
+    );
+
+    Ok(Some(new_content))
+}
+
+/// Returns a non-clobbering backup path next to `path`.
+///
+/// Uses `<stem>.pre-0.9.bak` as the base name so the user can tell what
+/// the backup is for. Appends a numeric suffix if it already exists.
+fn backup_path(path: &Path) -> PathBuf {
+    let base = path.with_extension("toml.pre-0.9.bak");
+    if !base.exists() {
+        return base;
+    }
+    for n in 1..1000 {
+        let candidate = path.with_extension(format!("toml.pre-0.9.bak.{n}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    base
 }
 
 /// Loads the configuration from disk, falling back to defaults.
@@ -59,6 +160,84 @@ pub fn try_load() -> Result<Config, String> {
 /// Non-existent files silently return defaults; other IO errors are logged.
 pub fn load() -> Config {
     load_or_default(config_path(), try_load, Config::default)
+}
+
+/// Snippet appended to `config.toml` when the `[workspaces]` section is
+/// missing. Documents the new options so users notice them on first load
+/// after upgrading.
+const WORKSPACES_SECTION_SNIPPET: &str = r##"
+# Added automatically -- new defaults from this version of mosaico
+[workspaces]
+# How a workspace switch is applied across monitors.
+# "per-monitor" (default): only the focused monitor switches.
+# "global": all monitors switch in lockstep, like Windows virtual desktops.
+mode = "per-monitor"
+
+# Per-workspace layout overrides (workspace number 1-8).
+# Available layouts: "bsp", "vertical-stack", "three-column".
+# [workspaces.layouts]
+# 1 = "vertical-stack"
+# 3 = "three-column"
+"##;
+
+/// Appends a documented `[workspaces]` section to `config.toml` when the
+/// user's file is missing it.
+///
+/// Mirrors [`merge_missing_keybindings`] and [`merge_missing_bar_widgets`]:
+/// new top-level sections introduced by future versions of mosaico are
+/// appended as commented or default-valued blocks so users discover them
+/// without losing their existing customizations.
+///
+/// No-op when the file does not exist (a brand-new install will get the
+/// full section from `mosaico init`'s template). Errors are logged and
+/// swallowed -- failure here must not prevent the daemon from starting.
+pub fn merge_missing_config_sections() {
+    let path = match config_path() {
+        Some(p) if p.exists() => p,
+        _ => return,
+    };
+
+    match append_missing_workspaces_section(&path) {
+        Ok(true) => eprintln!(
+            "Info: appended [workspaces] section to {} (new in this version)",
+            path.display()
+        ),
+        Ok(false) => {}
+        Err(e) => eprintln!("Warning: {e}"),
+    }
+}
+
+/// Path-pure helper for [`merge_missing_config_sections`]: returns
+/// `Ok(true)` when an append happened, `Ok(false)` when the file already
+/// has a `[workspaces]` section.
+fn append_missing_workspaces_section(path: &Path) -> Result<bool, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+
+    let doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|e| format!("could not parse {}: {e}", path.display()))?;
+
+    if doc.contains_key("workspaces") {
+        return Ok(false);
+    }
+
+    // Make sure the snippet starts on a fresh line even if the existing
+    // file does not end in a newline.
+    let mut to_append = String::new();
+    if !content.ends_with('\n') {
+        to_append.push('\n');
+    }
+    to_append.push_str(WORKSPACES_SECTION_SNIPPET);
+
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("could not open {} for appending: {e}", path.display()))?;
+    f.write_all(to_append.as_bytes())
+        .map_err(|e| format!("could not append to {}: {e}", path.display()))?;
+    Ok(true)
 }
 
 /// Tries to load and parse `keybindings.toml`.
@@ -379,5 +558,242 @@ fn load_or_default<T>(
                 default()
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod migration_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Returns a unique temp path for each call so parallel tests do not
+    /// collide on the shared system temp directory.
+    fn unique_temp_path() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let pid = std::process::id();
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        p.push(format!("mosaico-migration-test-{pid}-{n}.toml"));
+        p
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(path.with_extension("toml.pre-0.9.bak"));
+        for n in 1..10 {
+            let _ = std::fs::remove_file(path.with_extension(format!("toml.pre-0.9.bak.{n}")));
+        }
+    }
+
+    #[test]
+    fn migrates_legacy_section_and_writes_backup() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[layout.workspaces]
+1 = \"vertical-stack\"
+3 = \"three-column\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let migrated = migrate_config_if_needed(&path, original).unwrap();
+
+        assert!(migrated.is_some(), "expected migration to run");
+        let new_content = migrated.unwrap();
+        assert!(new_content.contains("[workspaces.layouts]"));
+        assert!(!new_content.contains("[layout.workspaces]"));
+        assert!(new_content.contains("1 = \"vertical-stack\""));
+
+        let backup = path.with_extension("toml.pre-0.9.bak");
+        assert!(backup.exists(), "backup file should exist");
+        let backup_contents = std::fs::read_to_string(&backup).unwrap();
+        assert_eq!(backup_contents, original, "backup must match original");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            on_disk, new_content,
+            "rewritten file must match returned content"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn no_legacy_section_is_a_noop() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[workspaces]
+mode = \"global\"
+
+[workspaces.layouts]
+2 = \"bsp\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let migrated = migrate_config_if_needed(&path, original).unwrap();
+        assert!(
+            migrated.is_none(),
+            "should not migrate when no legacy section"
+        );
+
+        let backup = path.with_extension("toml.pre-0.9.bak");
+        assert!(!backup.exists(), "no backup should be created");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(on_disk, original, "file must be untouched");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn second_run_is_idempotent() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[layout.workspaces]
+1 = \"bsp\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        // First pass migrates.
+        let first = migrate_config_if_needed(&path, original).unwrap();
+        assert!(first.is_some());
+        let after_first = std::fs::read_to_string(&path).unwrap();
+
+        // Second pass sees the already-migrated file and does nothing.
+        let second = migrate_config_if_needed(&path, &after_first).unwrap();
+        assert!(second.is_none(), "second migration must be a no-op");
+
+        let collision_backup = path.with_extension("toml.pre-0.9.bak.1");
+        assert!(
+            !collision_backup.exists(),
+            "no second backup should be created"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn existing_workspaces_layouts_wins_over_legacy() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[layout.workspaces]
+1 = \"bsp\"
+
+[workspaces]
+mode = \"global\"
+
+[workspaces.layouts]
+2 = \"three-column\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let migrated = migrate_config_if_needed(&path, original).unwrap().unwrap();
+
+        // Legacy section is gone.
+        assert!(!migrated.contains("[layout.workspaces]"));
+        // The pre-existing [workspaces.layouts] is preserved (workspace 2).
+        assert!(migrated.contains("2 = \"three-column\""));
+        // The legacy mapping (workspace 1 = bsp) is dropped because the
+        // user already had a [workspaces.layouts] section.
+        assert!(!migrated.contains("1 = \"bsp\""));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn appends_workspaces_section_when_missing() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[borders]
+width = 4
+";
+        std::fs::write(&path, original).unwrap();
+
+        let appended = append_missing_workspaces_section(&path).unwrap();
+        assert!(appended, "should append when [workspaces] is missing");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            on_disk.starts_with(original),
+            "existing content must be preserved verbatim"
+        );
+        assert!(on_disk.contains("[workspaces]"));
+        assert!(on_disk.contains("mode = \"per-monitor\""));
+        assert!(on_disk.contains("# [workspaces.layouts]"));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn does_not_append_when_section_present() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[workspaces]
+mode = \"global\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let appended = append_missing_workspaces_section(&path).unwrap();
+        assert!(!appended, "should not append when section already present");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(on_disk, original, "file must be untouched");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn append_handles_file_without_trailing_newline() {
+        let path = unique_temp_path();
+        let original = "[layout]\ngap = 8"; // no trailing newline
+        std::fs::write(&path, original).unwrap();
+
+        append_missing_workspaces_section(&path).unwrap();
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        // The section header must land on its own line, not be glued to
+        // `gap = 8`.
+        assert!(on_disk.contains("gap = 8\n"));
+        assert!(on_disk.contains("[workspaces]"));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn backup_path_avoids_collision() {
+        let path = unique_temp_path();
+        std::fs::write(&path, "").unwrap();
+
+        let first = backup_path(&path);
+        assert_eq!(first.extension().and_then(|e| e.to_str()), Some("bak"));
+        std::fs::write(&first, "").unwrap();
+
+        let second = backup_path(&path);
+        assert_ne!(first, second);
+        assert!(
+            second.to_string_lossy().ends_with(".bak.1"),
+            "second backup should append .1 suffix, got {}",
+            second.display()
+        );
+
+        cleanup(&path);
     }
 }

--- a/crates/mosaico-core/src/config/mod.rs
+++ b/crates/mosaico-core/src/config/mod.rs
@@ -22,8 +22,8 @@ pub use keybinding::{Keybinding, Modifier};
 pub use loader::{
     bar_path, config_dir, config_path, keybindings_path, load, load_bar, load_keybindings,
     load_merged_rules, load_rules, load_user_rules, merge_missing_bar_widgets,
-    merge_missing_keybindings, rules_path, try_load, try_load_bar, try_load_keybindings,
-    try_load_rules, try_load_user_rules, user_rules_path,
+    merge_missing_config_sections, merge_missing_keybindings, rules_path, try_load, try_load_bar,
+    try_load_keybindings, try_load_rules, try_load_user_rules, user_rules_path,
 };
 pub use rules::{WindowRule, default_rules, should_manage, validate_rules};
 pub use theme::{Theme, ThemeConfig};
@@ -40,6 +40,8 @@ pub struct Config {
     pub theme: ThemeConfig,
     /// Layout algorithm parameters.
     pub layout: LayoutConfig,
+    /// Workspace switching mode and per-workspace layout overrides.
+    pub workspaces: WorkspacesConfig,
     /// Border appearance settings.
     pub borders: BorderConfig,
     /// Mouse integration settings.

--- a/crates/mosaico-core/src/config/template_config.rs
+++ b/crates/mosaico-core/src/config/template_config.rs
@@ -25,9 +25,18 @@ hiding = "cloak"
 # Default layout algorithm: "bsp", "vertical-stack", or "three-column".
 default = "bsp"
 
+[workspaces]
+# How a workspace switch is applied across monitors.
+# "per-monitor" (default): only the focused monitor switches.
+# "global": all monitors switch in lockstep, like Windows virtual desktops.
+mode = "per-monitor"
+
 # Per-workspace layout overrides (workspace number 1-8).
-# [layout.workspaces]
+# Available layouts: "bsp", "vertical-stack", "three-column".
+# Workspaces without an entry use the [layout] default above.
+# [workspaces.layouts]
 # 1 = "vertical-stack"
+# 3 = "three-column"
 
 [borders]
 # Border width in pixels around the focused window.

--- a/crates/mosaico-core/src/config/types.rs
+++ b/crates/mosaico-core/src/config/types.rs
@@ -20,9 +20,6 @@ pub struct LayoutConfig {
     pub hiding: HidingBehaviour,
     /// Default layout for workspaces without an explicit override.
     pub default: LayoutKind,
-    /// Per-workspace layout overrides (workspace number 1–8 → layout).
-    #[serde(default)]
-    pub workspaces: HashMap<u8, LayoutKind>,
 }
 
 impl Default for LayoutConfig {
@@ -32,9 +29,21 @@ impl Default for LayoutConfig {
             ratio: 0.5,
             hiding: HidingBehaviour::default(),
             default: LayoutKind::default(),
-            workspaces: HashMap::new(),
         }
     }
+}
+
+/// Workspace-level configuration.
+///
+/// Holds the workspace switching mode and per-workspace layout
+/// overrides. See [`WorkspaceMode`] for the available modes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorkspacesConfig {
+    /// How a workspace switch is applied across monitors.
+    pub mode: WorkspaceMode,
+    /// Per-workspace layout overrides (workspace number 1–8 → layout).
+    pub layouts: HashMap<u8, LayoutKind>,
 }
 
 /// How windows are hidden when switching away from their workspace.
@@ -124,4 +133,16 @@ impl Default for BorderConfig {
             monocle: String::new(),
         }
     }
+}
+
+/// How a workspace switch is applied across monitors.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspaceMode {
+    /// Switching workspaces only affects the focused monitor (default).
+    #[default]
+    PerMonitor,
+    /// Switching workspaces affects every monitor in lockstep, mirroring
+    /// how Windows virtual desktops work.
+    Global,
 }

--- a/crates/mosaico-windows/src/daemon_loop.rs
+++ b/crates/mosaico-windows/src/daemon_loop.rs
@@ -16,6 +16,11 @@ use super::daemon_types::DaemonMsg;
 
 /// The inner daemon loop, separated so cleanup always runs in `run()`.
 pub(super) fn daemon_loop() -> WindowResult<()> {
+    // Append any missing top-level config sections introduced by newer
+    // versions of mosaico (e.g. [workspaces]) before loading, so the
+    // user's config.toml visibly tracks the latest schema.
+    config::merge_missing_config_sections();
+
     let config = config::load();
     mosaico_core::log::init(&config.logging);
 
@@ -44,6 +49,7 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
 
     let mut manager = TilingManager::new(
         &config.layout,
+        &config.workspaces,
         rules,
         config.borders,
         config.mouse.follows_focus,

--- a/crates/mosaico-windows/src/tiling/display.rs
+++ b/crates/mosaico-windows/src/tiling/display.rs
@@ -2,6 +2,7 @@
 
 use mosaico_core::Workspace;
 use mosaico_core::action::MAX_WORKSPACES;
+use mosaico_core::config::WorkspaceMode;
 
 use crate::monitor::MonitorInfo;
 
@@ -128,6 +129,20 @@ impl TilingManager {
         // Clamp focused monitor.
         if self.focused_monitor >= self.monitors.len() {
             self.focused_monitor = 0;
+        }
+
+        // In global mode, every monitor must share the same active
+        // workspace. New monitors default to workspace 0; align them to
+        // the focused monitor's workspace so the lockstep invariant holds.
+        if self.workspace_mode == WorkspaceMode::Global
+            && let Some(target) = self
+                .monitors
+                .get(self.focused_monitor)
+                .map(|m| m.active_workspace)
+        {
+            for mon in &mut self.monitors {
+                mon.active_workspace = target;
+            }
         }
 
         // Re-apply bar offsets and retile.

--- a/crates/mosaico-windows/src/tiling/lifecycle.rs
+++ b/crates/mosaico-windows/src/tiling/lifecycle.rs
@@ -53,11 +53,12 @@ impl TilingManager {
     /// startup the active layout is runtime state owned by `cycle-layout`
     /// and explicit `set-layout` actions. Config reload must not silently
     /// undo those choices when the user tweaks unrelated settings like gap
-    /// or borders. Changes to `[layout.workspaces]` take effect on restart.
+    /// or borders. Changes to `[workspaces.layouts]` take effect on restart.
     pub fn reload_config(&mut self, config: &mosaico_core::config::Config) {
         self.layout_gap = config.layout.gap;
         self.layout_ratio = config.layout.ratio;
         self.hiding = config.layout.hiding;
+        self.workspace_mode = config.workspaces.mode;
         self.border_config = config.borders.clone();
         self.mouse_follows_focus = config.mouse.follows_focus;
         self.apply_corner_preference_all();

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -12,7 +12,9 @@ use std::collections::HashSet;
 use std::time::Instant;
 
 use mosaico_core::action::MAX_WORKSPACES;
-use mosaico_core::config::{BorderConfig, HidingBehaviour, LayoutConfig, WindowRule};
+use mosaico_core::config::{
+    BorderConfig, HidingBehaviour, LayoutConfig, WindowRule, WorkspaceMode, WorkspacesConfig,
+};
 use mosaico_core::{Action, Rect, WindowResult, Workspace};
 
 use crate::bar::BarState;
@@ -75,6 +77,8 @@ pub struct TilingManager {
     focus_from_mouse: bool,
     /// How windows are hidden during workspace switches.
     hiding: HidingBehaviour,
+    /// Whether workspace switches affect one monitor or all monitors.
+    pub(super) workspace_mode: WorkspaceMode,
     /// Windows hidden programmatically by workspace switching.
     ///
     /// Events for these hwnds are ignored until they are shown again.
@@ -112,6 +116,7 @@ impl TilingManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         layout_config: &LayoutConfig,
+        workspaces_config: &WorkspacesConfig,
         rules: Vec<WindowRule>,
         border_config: BorderConfig,
         mouse_follows_focus: bool,
@@ -124,8 +129,8 @@ impl TilingManager {
                 workspaces: (0..MAX_WORKSPACES)
                     .map(|i| {
                         let ws_num = i + 1;
-                        let kind = layout_config
-                            .workspaces
+                        let kind = workspaces_config
+                            .layouts
                             .get(&ws_num)
                             .copied()
                             .unwrap_or(layout_config.default);
@@ -153,6 +158,7 @@ impl TilingManager {
             focus_from_mouse: false,
             applying_layout: false,
             hiding: layout_config.hiding,
+            workspace_mode: workspaces_config.mode,
             hidden_by_switch: HashSet::new(),
             ws_switch_cooldown: None,
             self_elevated,

--- a/crates/mosaico-windows/src/tiling/tests/workspace_tests.rs
+++ b/crates/mosaico-windows/src/tiling/tests/workspace_tests.rs
@@ -21,7 +21,7 @@ fn goto_workspace_logic() {
     assert!(hidden.contains(&10));
     assert!(hidden.contains(&20));
 
-    // Show ws 1 windows — remove from hidden
+    // Show ws 1 windows -- remove from hidden
     for &hwnd in mon.active_ws().handles() {
         hidden.remove(&hwnd);
     }
@@ -69,4 +69,87 @@ fn goto_same_workspace_is_noop() {
     // Switching to already-active workspace should be a no-op
     assert_eq!(mon.active_workspace, 0);
     // The real code returns early when active_workspace == target
+}
+
+#[test]
+fn per_monitor_mode_only_updates_focused_monitor() {
+    // Per-monitor mode: a workspace switch on the focused monitor must not
+    // touch any other monitor's active_workspace.
+    let mut monitors = [make_monitor(1), make_monitor(2), make_monitor(3)];
+    monitors[0].active_workspace = 0;
+    monitors[1].active_workspace = 4;
+    monitors[2].active_workspace = 7;
+
+    let focused = 1;
+    let target = 2;
+
+    // Simulate: only the focused monitor advances.
+    monitors[focused].active_workspace = target;
+
+    assert_eq!(monitors[0].active_workspace, 0);
+    assert_eq!(monitors[1].active_workspace, target);
+    assert_eq!(monitors[2].active_workspace, 7);
+}
+
+#[test]
+fn global_mode_updates_every_monitor() {
+    // Global mode: a workspace switch updates every monitor's
+    // active_workspace to the same index, mirroring Windows virtual
+    // desktops. Each monitor still owns its own window list.
+    let mut monitors = [make_monitor(1), make_monitor(2), make_monitor(3)];
+    monitors[0].workspaces[0].add(10);
+    monitors[1].workspaces[3].add(20); // started on ws 3
+    monitors[2].workspaces[5].add(30); // started on ws 5
+    monitors[1].active_workspace = 3;
+    monitors[2].active_workspace = 5;
+
+    let target = 2; // goto-workspace 3 (1-indexed)
+
+    // Simulate the global-mode invariant: every monitor flips to `target`.
+    for mon in &mut monitors {
+        mon.active_workspace = target;
+    }
+
+    for mon in &monitors {
+        assert_eq!(mon.active_workspace, target);
+    }
+    // Window membership is unchanged -- windows remain on their original
+    // workspaces; they're just hidden until the user comes back.
+    assert!(monitors[0].workspaces[0].contains(10));
+    assert!(monitors[1].workspaces[3].contains(20));
+    assert!(monitors[2].workspaces[5].contains(30));
+}
+
+#[test]
+fn global_mode_send_to_workspace_keeps_monitors_in_sync() {
+    // send-to-workspace in global mode: window moves on the focused
+    // monitor, then every monitor flips to the target workspace.
+    let mut monitors = [make_monitor(1), make_monitor(2)];
+    monitors[0].workspaces[0].add(100);
+    monitors[1].workspaces[0].add(200);
+
+    let focused = 0;
+    let target_ws = 4;
+
+    // Step 1: move the window on the focused monitor.
+    monitors[focused].workspaces[0].remove(100);
+    monitors[focused].workspaces[target_ws].add(100);
+    monitors[focused].active_workspace = target_ws;
+
+    // Step 2: flip every other monitor to the same workspace.
+    for (i, mon) in monitors.iter_mut().enumerate() {
+        if i == focused {
+            continue;
+        }
+        mon.active_workspace = target_ws;
+    }
+
+    assert_eq!(monitors[0].active_workspace, target_ws);
+    assert_eq!(monitors[1].active_workspace, target_ws);
+    assert!(monitors[0].workspaces[target_ws].contains(100));
+    // The other monitor's window stays where it was (window 200 is
+    // still on workspace 0 of monitor 1, just hidden because monitor 1
+    // is now showing workspace 4).
+    assert!(monitors[1].workspaces[0].contains(200));
+    assert_eq!(monitors[1].workspaces[target_ws].len(), 0);
 }

--- a/crates/mosaico-windows/src/tiling/workspace.rs
+++ b/crates/mosaico-windows/src/tiling/workspace.rs
@@ -6,7 +6,7 @@
 
 use std::time::{Duration, Instant};
 
-use mosaico_core::config::HidingBehaviour;
+use mosaico_core::config::{HidingBehaviour, WorkspaceMode};
 
 use super::TilingManager;
 
@@ -19,26 +19,56 @@ use super::TilingManager;
 const WS_SWITCH_COOLDOWN: Duration = Duration::from_millis(500);
 
 impl TilingManager {
-    /// Switches to workspace `n` (1-indexed) on the focused monitor.
+    /// Switches to workspace `n` (1-indexed).
     ///
-    /// Hides windows on the current workspace, shows windows on the
-    /// target, retiles, and focuses the first window.
+    /// In `per-monitor` mode (the default) this only switches the focused
+    /// monitor. In `global` mode every monitor switches in lockstep so all
+    /// monitors mirror the same workspace number, like Windows virtual
+    /// desktops.
     pub(super) fn goto_workspace(&mut self, n: u8) {
         let idx = (n - 1) as usize;
-        let mon_idx = self.focused_monitor;
+
+        match self.workspace_mode {
+            WorkspaceMode::PerMonitor => {
+                let mon_idx = self.focused_monitor;
+                self.goto_workspace_on(mon_idx, idx, /* refocus */ true);
+            }
+            WorkspaceMode::Global => {
+                let focused = self.focused_monitor;
+                // Switch every monitor's active workspace in lockstep.
+                // Refocus only on the previously focused monitor so the
+                // cursor/foreground stays where the user was working.
+                for mon_idx in 0..self.monitors.len() {
+                    let refocus = mon_idx == focused;
+                    self.goto_workspace_on(mon_idx, idx, refocus);
+                }
+            }
+        }
+    }
+
+    /// Performs the goto-workspace operation on a single monitor.
+    ///
+    /// Hides the previous workspace's windows, shows the target workspace's
+    /// windows, retiles, and (when `refocus` is true) restores keyboard
+    /// focus to the remembered or first window. A no-op when the monitor
+    /// is already on `idx`.
+    fn goto_workspace_on(&mut self, mon_idx: usize, idx: usize, refocus: bool) {
         let Some(mon) = self.monitors.get(mon_idx) else {
             return;
         };
         if mon.active_workspace == idx {
-            return; // already there
+            return;
         }
 
         self.ws_switch_cooldown = Some(Instant::now() + WS_SWITCH_COOLDOWN);
 
-        // Remember which window was focused before leaving.
+        // Remember which window was focused before leaving -- only meaningful
+        // on the focused monitor, but harmless on others (last_focused gets
+        // set to None on monitors where the user wasn't focused).
+        let last_focused_value = if refocus { self.focused_window } else { None };
         self.monitors[mon_idx]
             .active_ws_mut()
-            .set_last_focused(self.focused_window);
+            .set_last_focused(last_focused_value);
 
         // Collect the previous workspace's handles so we can hide them
         // AFTER the target workspace's window is foregrounded. Hiding
@@ -61,26 +91,30 @@ impl TilingManager {
 
         self.apply_layout_on(mon_idx);
 
-        // Restore focus to the last focused window on this workspace.
-        // In monocle mode, prefer the monocle window. Fall back to the
-        // first window if the remembered window is no longer present.
-        let ws = self.monitors[mon_idx].active_ws();
-        let target = if ws.monocle() {
-            ws.monocle_window()
-                .filter(|&h| ws.contains(h))
-                .or_else(|| ws.last_focused().filter(|&h| ws.contains(h)))
-                .or_else(|| ws.handles().first().copied())
-        } else {
-            ws.last_focused()
-                .filter(|&h| ws.contains(h))
-                .or_else(|| ws.handles().first().copied())
-        };
+        // Restore focus only on the focused monitor -- in global mode the
+        // other monitors retile silently without stealing foreground.
+        if refocus {
+            // Restore focus to the last focused window on this workspace.
+            // In monocle mode, prefer the monocle window. Fall back to the
+            // first window if the remembered window is no longer present.
+            let ws = self.monitors[mon_idx].active_ws();
+            let target = if ws.monocle() {
+                ws.monocle_window()
+                    .filter(|&h| ws.contains(h))
+                    .or_else(|| ws.last_focused().filter(|&h| ws.contains(h)))
+                    .or_else(|| ws.handles().first().copied())
+            } else {
+                ws.last_focused()
+                    .filter(|&h| ws.contains(h))
+                    .or_else(|| ws.handles().first().copied())
+            };
 
-        if let Some(hwnd) = target {
-            self.focus_and_update_border(hwnd);
-        } else {
-            self.focused_window = None;
-            self.update_border();
+            if let Some(hwnd) = target {
+                self.focus_and_update_border(hwnd);
+            } else {
+                self.focused_window = None;
+                self.update_border();
+            }
         }
 
         // Now hide the previous workspace's windows. Doing this AFTER
@@ -95,7 +129,7 @@ impl TilingManager {
 
         mosaico_core::log_debug!(
             "goto-workspace {} on mon {} (from ws {}, {} windows)",
-            n,
+            idx + 1,
             mon_idx,
             prev_ws + 1,
             self.monitors[mon_idx].active_ws().len()
@@ -106,7 +140,9 @@ impl TilingManager {
     /// same monitor, then follows it there.
     ///
     /// Moves the window to the target workspace, switches to that
-    /// workspace, and focuses the moved window.
+    /// workspace, and focuses the moved window. In `global` mode every
+    /// other monitor also switches its active workspace to `n` so the
+    /// view stays in sync.
     pub(super) fn send_to_workspace(&mut self, n: u8) {
         let target_ws = (n - 1) as usize;
         let Some(hwnd) = self.focused_window else {
@@ -138,7 +174,7 @@ impl TilingManager {
             self.hide_window(h);
         }
 
-        // Switch to the target workspace.
+        // Switch to the target workspace on the focused monitor.
         self.monitors[mon_idx].active_workspace = target_ws;
 
         // Show all windows on the target workspace.
@@ -160,5 +196,17 @@ impl TilingManager {
 
         self.apply_layout_on(mon_idx);
         self.focus_and_update_border(hwnd);
+
+        // In global mode, flip every other monitor to the same workspace
+        // so the user follows the window into a coherent virtual-desktop
+        // view across all displays.
+        if self.workspace_mode == WorkspaceMode::Global {
+            for other_idx in 0..self.monitors.len() {
+                if other_idx == mon_idx {
+                    continue;
+                }
+                self.goto_workspace_on(other_idx, target_ws, /* refocus */ false);
+            }
+        }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,11 @@ gap = 8          # Pixel gap between windows (0-200)
 ratio = 0.5      # BSP split ratio (0.1-0.9)
 hiding = "cloak" # How windows hide on workspace switch: "cloak", "hide", "minimize"
 
-[layout.workspaces]  # Per-workspace layout overrides
+[workspaces]
+mode = "per-monitor"  # "per-monitor" (default) or "global"
+
+[workspaces.layouts]  # Per-workspace layout overrides
+# Available values: "bsp", "vertical-stack", "three-column"
 1 = "vertical-stack"
 3 = "three-column"
 
@@ -227,8 +231,9 @@ detected and applied while the daemon is running. The config file watcher
   are reloaded. The tiling manager calls `reload_config()` which updates the
   layout gap/ratio, hiding strategy, and `BorderConfig`, then retiles all
   windows. If the theme changed, bar colors are re-resolved. Hiding changes
-  take effect on the next workspace switch. Per-workspace layout overrides
-  (`[layout.workspaces]` and `layout.default`) are applied at startup only —
+  take effect on the next workspace switch. The workspace mode
+  (`workspaces.mode`) is reloaded live. Per-workspace layout overrides
+  (`[workspaces.layouts]` and `layout.default`) are applied at startup only;
   reloading does not override the active layout chosen via `cycle-layout`
   or `set-layout`; restart the daemon to pick up changes.
 - **rules.toml**: window rules are replaced via `reload_rules()`. New rules

--- a/docs/tiling-layout.md
+++ b/docs/tiling-layout.md
@@ -139,7 +139,9 @@ display (`"BSP"`, `"VStack"`, `"3Col"`).
 
 ### Per-Workspace Configuration
 
-The `[layout]` section of `config.toml` supports:
+The `[layout]` section sets defaults that apply to every workspace, and the
+`[workspaces.layouts]` section overrides those defaults for specific workspace
+numbers:
 
 ```toml
 [layout]
@@ -147,18 +149,25 @@ gap = 8
 ratio = 0.5
 default = "bsp"            # default layout for all workspaces
 
-[layout.workspaces]
+[workspaces.layouts]
 3 = "vertical-stack"       # workspace 3 uses VerticalStack
 5 = "three-column"         # workspace 5 uses ThreeColumn
 ```
 
-- `default` -- the `LayoutKind` used for workspaces without an explicit
-  override (default: `"bsp"`)
-- `workspaces` -- a map of workspace number (1-8) to `LayoutKind`; workspaces
-  listed here start with the specified layout instead of `default`
+- `layout.default` -- the `LayoutKind` used for workspaces without an
+  explicit override (default: `"bsp"`)
+- `workspaces.layouts` -- a map of workspace number (1-8) to `LayoutKind`;
+  workspaces listed here start with the specified layout instead of
+  `layout.default`
 
-`LayoutKind` is serialized in kebab-case: `"bsp"`, `"vertical-stack"`,
-`"three-column"`.
+Both fields accept any of the three `LayoutKind` values, serialized in
+kebab-case:
+
+| TOML value | Layout |
+|------------|--------|
+| `"bsp"` | `LayoutKind::Bsp` -- recursive binary space partitioning (default) |
+| `"vertical-stack"` | `LayoutKind::VerticalStack` -- master pane left, vertical stack right |
+| `"three-column"` | `LayoutKind::ThreeColumn` -- master pane center, stacks on both sides |
 
 ## TilingManager
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,8 +1,17 @@
 # Workspaces
 
-Each monitor in Mosaico supports up to 8 independent workspaces. Only one
-workspace is active per monitor at a time. Switching workspaces hides the
-current windows and shows the target workspace's windows.
+Mosaico supports up to 8 workspaces. Each monitor has its own per-workspace
+window list; windows never migrate between monitors as part of a switch.
+Only one workspace is active per monitor at a time. Switching workspaces
+hides the current windows and shows the target workspace's windows.
+
+The `workspaces.mode` config field controls how a switch propagates across
+monitors:
+
+- `"per-monitor"` (default) -- only the focused monitor's
+  `active_workspace` advances.
+- `"global"` -- every monitor's `active_workspace` advances to the same
+  index in lockstep, mirroring Windows virtual desktops.
 
 ## Architecture
 
@@ -13,14 +22,18 @@ current windows and shows the target workspace's windows.
 | `crates/mosaico-core/src/action.rs` | `GoToWorkspace(u8)`, `SendToWorkspace(u8)`, `MAX_WORKSPACES` |
 | `crates/mosaico-core/src/workspace.rs` | `Workspace` -- ordered window handle collection |
 | `crates/mosaico-core/src/config/keybinding.rs` | Default workspace keybindings |
-| `crates/mosaico-windows/src/tiling/mod.rs` | `MonitorState` with `Vec<Workspace>`, `active_workspace` |
-| `crates/mosaico-windows/src/tiling/workspace.rs` | `goto_workspace()`, `send_to_workspace()` |
+| `crates/mosaico-windows/src/tiling/mod.rs` | `MonitorState` with `Vec<Workspace>`, `active_workspace`; `TilingManager.workspace_mode` |
+| `crates/mosaico-windows/src/tiling/workspace.rs` | `goto_workspace()`, `goto_workspace_on()`, `send_to_workspace()` |
+| `crates/mosaico-core/src/config/types.rs` | `WorkspacesConfig`, `WorkspaceMode` |
 
 ### Key Types
 
 - `MonitorState` -- per-monitor state holding `Vec<Workspace>` (8 workspaces),
   `active_workspace: usize` (0-indexed), and `monocle: bool`
 - `MAX_WORKSPACES: u8 = 8` -- public constant in `mosaico-core`
+- `WorkspacesConfig` -- top-level `[workspaces]` section: `mode: WorkspaceMode`
+  and `layouts: HashMap<u8, LayoutKind>` (per-workspace layout overrides)
+- `WorkspaceMode` -- `PerMonitor` (default) or `Global`
 
 ## Actions
 
@@ -34,20 +47,30 @@ Actions use 1-based indexing in the user-facing interface (config, CLI) and
 
 ## Switching Workspaces
 
-`goto_workspace(n)` (in `tiling/workspace.rs`):
+`goto_workspace(n)` (in `tiling/workspace.rs`) dispatches on
+`workspace_mode`:
 
-1. If already on workspace N, does nothing
+- `PerMonitor` -- calls `goto_workspace_on(focused_monitor, n, refocus=true)`.
+- `Global` -- iterates every monitor and calls `goto_workspace_on(i, n,
+  refocus = (i == focused_monitor))`. Only the previously-focused monitor
+  takes keyboard focus; the other monitors retile silently.
+
+`goto_workspace_on(mon_idx, idx, refocus)` performs the per-monitor work:
+
+1. If the monitor is already on workspace `idx`, does nothing
 2. Hides all windows in the current workspace using the configured hiding
    strategy (see below)
 3. For `Hide` and `Minimize` strategies: adds hidden windows to
    `hidden_by_switch` set to prevent spurious event handlers from removing
    them. Skipped for `Cloak` because cloaking does not fire events.
-4. Sets `active_workspace` to N
+4. Sets `active_workspace` to `idx`
 5. Shows all windows in the target workspace (reverses the hiding strategy)
 6. For `Hide` and `Minimize` strategies: removes shown windows from
    `hidden_by_switch`
 7. Retiles the monitor
-8. Focuses the first window in the new workspace
+8. When `refocus` is true, focuses the first window in the new workspace
+   (or the remembered `last_focused`); otherwise leaves keyboard focus
+   alone
 
 ### Hiding Behaviour
 
@@ -98,12 +121,15 @@ workspace and automatically switches to that workspace.
 `send_to_workspace(n)` (in `tiling/workspace.rs`):
 
 1. Removes the focused window from the current workspace
-2. Adds it to workspace N
-3. Hides the window and adds it to `hidden_by_switch`
-4. Retiles the current workspace
-5. Focuses the next available window
+2. Adds it to workspace N on the same monitor
+3. Hides the source workspace's remaining windows
+4. Sets `active_workspace = n` on the focused monitor
+5. Shows the target workspace's windows and focuses the moved window
+6. In `Global` mode, calls `goto_workspace_on` for every other monitor
+   (with `refocus=false`) so all monitors converge on workspace N
 
-The sent window will appear when the user switches to workspace N.
+The window itself never crosses monitors. It stays on the monitor it was
+on; global mode just keeps the *view* coherent across displays.
 
 ## Workspace Initialization
 
@@ -159,7 +185,13 @@ N is 1-8. Parsing validates the range and rejects invalid workspace numbers.
 - **`hidden_by_switch` tracking** is essential for Hide and Minimize modes
   to prevent the tiling manager from interpreting programmatic hides as
   window closures. Skipped for Cloak mode which fires no events.
-- **Per-monitor workspaces** rather than global workspaces match the
-  multi-monitor mental model where each monitor is independent.
+- **Per-monitor by default, global as opt-in.** Per-monitor matches the
+  mental model where each monitor is independent (you can flip one screen
+  without disturbing the others). The `Global` mode is for users who
+  prefer Windows-virtual-desktop semantics. The choice is one config field
+  (`workspaces.mode`); window ownership is unchanged across modes.
+- **Windows never migrate between monitors during a switch.** Each
+  monitor owns its own per-workspace window list. Global mode only
+  synchronizes the *active workspace index*, not window placement.
 - **Workspace 1 is always the initial active workspace**. New windows
   created after startup go to the active workspace of the focused monitor.

--- a/website/src/README.md
+++ b/website/src/README.md
@@ -12,7 +12,8 @@ line or via global keyboard shortcuts.
 - **Automatic tiling** -- windows are arranged in a BSP layout the moment
   they open, close, or are moved between monitors.
 - **Vim-style navigation** -- focus and move windows with `Alt + H/J/K/L`.
-- **Workspaces** -- up to 8 independent workspaces per monitor.
+- **Workspaces** -- up to 8 workspaces, switching either per-monitor
+  (default) or globally across every display, like Windows virtual desktops.
 - **Multi-monitor** -- each monitor is managed independently with
   cross-monitor navigation.
 - **Focus borders** -- colored overlay border around the focused window.

--- a/website/src/guide/configuration.md
+++ b/website/src/guide/configuration.md
@@ -26,10 +26,17 @@ gap = 8          # Pixel gap between windows (0-200)
 ratio = 0.5      # BSP split ratio (0.1-0.9)
 hiding = "cloak" # How windows hide on workspace switch: "cloak", "hide", "minimize"
 
-[layout.workspaces]
+[workspaces]
+# How a workspace switch is applied across monitors.
+# "per-monitor" (default): only the focused monitor switches.
+# "global": all monitors switch in lockstep, like Windows virtual desktops.
+mode = "per-monitor"
+
+[workspaces.layouts]
+# Available: "bsp", "vertical-stack", "three-column"
 1 = "three-column"    # Override layout for workspace 1
 3 = "vertical-stack"  # Override layout for workspace 3
-# Workspaces without an entry use the default layout
+# Workspaces without an entry use [layout].default
 
 [borders]
 width = 4              # Border thickness in pixels (0-32)

--- a/website/src/guide/tiling-layout.md
+++ b/website/src/guide/tiling-layout.md
@@ -101,20 +101,50 @@ default = "bsp"       # Default layout for all workspaces
 ### Per-Workspace Layout
 
 You can assign a specific layout to individual workspaces using the
-`[layout.workspaces]` section. Workspace numbers range from 1 to 8.
+`[workspaces.layouts]` section. Workspace numbers range from 1 to 8.
+
+The available layout values are:
+
+| Value | Layout |
+|-------|--------|
+| `"bsp"` | Binary Space Partitioning (default) |
+| `"vertical-stack"` | Master pane left, vertical stack right |
+| `"three-column"` | Master pane center, stacks on both sides |
 
 ```toml
 [layout]
 default = "bsp"
 
-[layout.workspaces]
+[workspaces.layouts]
 1 = "three-column"     # Workspace 1 always uses ThreeColumn
 3 = "vertical-stack"   # Workspace 3 always uses VerticalStack
 ```
 
-Workspaces without an entry in this table use the `default` layout. You
+Workspaces without an entry in this table use the `layout.default`. You
 can still cycle layouts at runtime with **Alt + N** -- the per-workspace
 config only controls the initial layout when the daemon starts.
+
+### Workspace Mode
+
+`workspaces.mode` controls how a workspace switch propagates across
+monitors:
+
+```toml
+[workspaces]
+mode = "per-monitor"   # default
+# mode = "global"
+```
+
+- **per-monitor** (default) -- a workspace switch only affects the focused
+  monitor. Other monitors keep their current workspace, so you can flip
+  one screen without disturbing the others.
+- **global** -- a workspace switch flips every monitor to the same
+  workspace number in lockstep, mirroring Windows virtual desktops. Each
+  monitor still owns its own window list per workspace; the mode just
+  syncs which workspace number every monitor is showing.
+
+The mode is hot-reloaded: edit `config.toml` and the next workspace
+switch follows the new mode without restarting the daemon.
 
 ## Monocle Mode
 

--- a/website/src/guide/workspaces.md
+++ b/website/src/guide/workspaces.md
@@ -1,7 +1,9 @@
 # Workspaces
 
-Mosaico supports up to 8 independent workspaces per monitor. Each workspace
-maintains its own set of tiled windows.
+Mosaico supports up to 8 workspaces. Each workspace maintains its own set
+of tiled windows. By default each monitor switches workspaces independently;
+you can opt into a global mode where every monitor switches in lockstep
+(see [Workspace Mode](#workspace-mode) below).
 
 ## Switching Workspaces
 
@@ -61,10 +63,32 @@ hiding = "cloak"   # "cloak", "hide", or "minimize"
 their taskbar icons, so you can still see all running apps. Clicking a
 cloaked window's taskbar icon automatically switches to its workspace.
 
-## Per-Monitor Workspaces
+## Workspace Mode
 
-Each monitor has its own independent set of 8 workspaces. Switching
-workspaces on one monitor does not affect other monitors.
+`workspaces.mode` in `config.toml` controls how a workspace switch
+propagates across monitors:
+
+```toml
+[workspaces]
+mode = "per-monitor"   # default
+# mode = "global"
+```
+
+| Mode | Behavior |
+|------|----------|
+| `"per-monitor"` (default) | Switching workspaces only affects the focused monitor. The other monitors keep showing whatever workspace they were on. |
+| `"global"` | Every monitor switches to the same workspace number in lockstep, mirroring Windows virtual desktops. |
+
+In both modes each monitor still owns its own window list per workspace;
+windows do not jump between displays. The mode only controls which
+monitors flip when you press `Alt + N` or run `mosaico action goto-workspace N`.
+
+`send-to-workspace` in `global` mode moves the window to the target
+workspace on its current monitor, then flips every other monitor to the
+same workspace number so the view stays in sync.
+
+The mode is hot-reloaded: change it in `config.toml` and the next
+workspace switch follows the new mode without restarting the daemon.
 
 ## Status Bar Integration
 


### PR DESCRIPTION
## Summary

Closes #7. Introduces a top-level `[workspaces]` config section with two new fields:

- **`mode = "per-monitor" | "global"`** -- controls whether `Alt+1..8` flips only the focused monitor (default, current behavior) or every monitor in lockstep, mirroring Windows virtual desktops.
- **`layouts`** -- the per-workspace layout override map, moved here from `[layout.workspaces]`.

Each monitor still owns its own per-workspace window list; global mode only synchronizes the active workspace *index*, not window placement. `send-to-workspace` in global mode moves the window on the focused monitor and then flips every other monitor to the same workspace number so the view stays in sync.

## Schema

- New `WorkspacesConfig { mode, layouts }` and `WorkspaceMode` enum in `mosaico-core`.
- `LayoutConfig.workspaces` removed.
- `TilingManager` gains a `workspace_mode` field, refreshed on config reload so mode changes are hot-applied.
- Display-change handler aligns every monitor's `active_workspace` in global mode so a hotplugged display joins the lockstep view.

## Migration

- On config load, a legacy `[layout.workspaces]` section is detected, the file is backed up to `config.toml.pre-0.9.bak` (with numeric suffixes on collision), and rewritten to `[workspaces.layouts]` using `toml_edit` so comments and formatting are preserved. Idempotent.
- Existing users without the legacy section get the new `[workspaces]` block appended on next daemon start so the option is discoverable, mirroring the `merge_missing_keybindings` / `merge_missing_bar_widgets` pattern.

## Tests

- 5 migration unit tests (legacy detection, backup, idempotence, conflict policy, backup-path collision).
- 3 section-append unit tests (append when missing, no-op when present, file without trailing newline).
- 4 workspace-mode tests covering per-monitor isolation, global lockstep on `goto-workspace`, and global `send-to-workspace` synchronization.
- All 200+ lib tests pass.

## Docs

- `configuration.md`, `tiling-layout.md`, and `workspaces.md` updated in both `docs/` and `website/src/guide/`. The new section, both modes, and all three `LayoutKind` values are documented.
- Auto-append snippet and `mosaico init` template list the available layout values.
- Separate commit refreshes the README's keybinding table and CLI actions list with previously-undocumented defaults (cycle layout, minimize, workspaces, pause).

## Test plan

- [ ] Fresh install: run `mosaico init`, confirm the generated `config.toml` includes a `[workspaces]` section with `mode = "per-monitor"` and a commented `[workspaces.layouts]` example.
- [ ] Existing install with no `[workspaces]` section: start the daemon, confirm an `Info: appended [workspaces] section ...` line is logged and the section is appended to `config.toml`. Re-run, confirm idempotence.
- [ ] Existing install with legacy `[layout.workspaces]`: start the daemon, confirm migration log line, confirm `config.toml.pre-0.9.bak` exists matching the original, confirm `config.toml` now has `[workspaces.layouts]` instead of `[layout.workspaces]`.
- [ ] Per-monitor mode (default): `Alt+1..8` only switches the focused monitor.
- [ ] Set `mode = "global"`, save: next `Alt+1..8` switches every monitor in lockstep without restarting the daemon.
- [ ] In global mode, `Alt+Shift+3` from monitor A: window moves to workspace 3 on monitor A and every monitor flips to workspace 3.
- [ ] Hotplug a monitor while in global mode: new monitor's `active_workspace` matches the others.
