### PR TITLE
refactor(borders)!: move focused/monocle colors under [borders.colors]

### DIFF
--- a/crates/mosaico-core/src/config/loader.rs
+++ b/crates/mosaico-core/src/config/loader.rs
@@ -63,24 +63,33 @@ pub fn try_load() -> Result<Config, String> {
     Ok(config)
 }
 
-/// Migrates a legacy `[layout.workspaces]` section to `[workspaces.layouts]`.
+/// Detects and applies all legacy -> current schema migrations:
 ///
-/// On detection: backs up the original file (aborting if the backup write
-/// fails), rewrites the config in place using `toml_edit` so comments and
-/// formatting survive, and returns the new content for the caller to parse.
+/// - `[layout.workspaces]` -> `[workspaces.layouts]`
+/// - `[borders] focused = ...` / `monocle = ...` -> `[borders.colors]`
 ///
-/// Returns `Ok(None)` when no migration was needed (no legacy section).
+/// On detection of any legacy pattern: backs up the original file
+/// (aborting if the backup write fails), rewrites the config in place
+/// using `toml_edit` so comments and formatting survive, and returns
+/// the new content for the caller to parse.
+///
+/// Returns `Ok(None)` when no migration was needed.
 fn migrate_config_if_needed(path: &Path, content: &str) -> Result<Option<String>, String> {
     let mut doc: toml_edit::DocumentMut = content
         .parse()
         .map_err(|e| format!("{}: {e}", path.display()))?;
 
-    let has_legacy = doc
+    let has_legacy_workspaces = doc
         .get("layout")
         .and_then(|t| t.as_table())
         .is_some_and(|t| t.contains_key("workspaces"));
 
-    if !has_legacy {
+    let has_legacy_borders = doc
+        .get("borders")
+        .and_then(|t| t.as_table())
+        .is_some_and(|t| t.contains_key("focused") || t.contains_key("monocle"));
+
+    if !has_legacy_workspaces && !has_legacy_borders {
         return Ok(None);
     }
 
@@ -95,33 +104,16 @@ fn migrate_config_if_needed(path: &Path, content: &str) -> Result<Option<String>
         )
     })?;
 
-    // Pull [layout.workspaces] out and place it under [workspaces.layouts].
-    let legacy = doc
-        .get_mut("layout")
-        .and_then(|t| t.as_table_mut())
-        .and_then(|t| t.remove("workspaces"));
+    let mut applied: Vec<&'static str> = Vec::new();
 
-    if let Some(legacy_item) = legacy {
-        if doc.get("workspaces").is_none() {
-            doc.insert(
-                "workspaces",
-                toml_edit::Item::Table(toml_edit::Table::new()),
-            );
-        }
-        // If the user already has [workspaces.layouts], keep it and drop
-        // the legacy section. Otherwise install the legacy values there.
-        let workspaces = doc
-            .get_mut("workspaces")
-            .and_then(|t| t.as_table_mut())
-            .ok_or_else(|| {
-                format!(
-                    "{}: [workspaces] is not a table -- cannot migrate",
-                    path.display()
-                )
-            })?;
-        if !workspaces.contains_key("layouts") {
-            workspaces.insert("layouts", legacy_item);
-        }
+    if has_legacy_workspaces {
+        migrate_workspaces_section(&mut doc, path)?;
+        applied.push("[layout.workspaces] -> [workspaces.layouts]");
+    }
+
+    if has_legacy_borders {
+        migrate_border_colors(&mut doc, path)?;
+        applied.push("[borders] focused/monocle -> [borders.colors]");
     }
 
     let new_content = doc.to_string();
@@ -129,11 +121,91 @@ fn migrate_config_if_needed(path: &Path, content: &str) -> Result<Option<String>
         .map_err(|e| format!("could not write migrated config to {}: {e}", path.display()))?;
 
     eprintln!(
-        "Info: migrated [layout.workspaces] -> [workspaces.layouts]. Backup saved at {}",
+        "Info: migrated config keys ({}). Backup saved at {}",
+        applied.join(", "),
         backup.display()
     );
 
     Ok(Some(new_content))
+}
+
+/// Moves `[layout.workspaces]` to `[workspaces.layouts]`.
+///
+/// If the user already has `[workspaces.layouts]`, keeps it and drops
+/// the legacy mapping (the new section wins).
+fn migrate_workspaces_section(doc: &mut toml_edit::DocumentMut, path: &Path) -> Result<(), String> {
+    let legacy = doc
+        .get_mut("layout")
+        .and_then(|t| t.as_table_mut())
+        .and_then(|t| t.remove("workspaces"));
+
+    let Some(legacy_item) = legacy else {
+        return Ok(());
+    };
+
+    if doc.get("workspaces").is_none() {
+        doc.insert(
+            "workspaces",
+            toml_edit::Item::Table(toml_edit::Table::new()),
+        );
+    }
+    let workspaces = doc
+        .get_mut("workspaces")
+        .and_then(|t| t.as_table_mut())
+        .ok_or_else(|| {
+            format!(
+                "{}: [workspaces] is not a table -- cannot migrate",
+                path.display()
+            )
+        })?;
+
+    if !workspaces.contains_key("layouts") {
+        workspaces.insert("layouts", legacy_item);
+    }
+    Ok(())
+}
+
+/// Moves top-level `focused` / `monocle` keys from `[borders]` into a
+/// `[borders.colors]` sub-table.
+///
+/// If the user already has `[borders.colors].focused` or `.monocle`,
+/// the existing nested values win and the legacy keys are dropped.
+fn migrate_border_colors(doc: &mut toml_edit::DocumentMut, path: &Path) -> Result<(), String> {
+    let borders = doc.get_mut("borders").and_then(|t| t.as_table_mut());
+    let Some(borders) = borders else {
+        return Ok(());
+    };
+
+    let legacy_focused = borders.remove("focused");
+    let legacy_monocle = borders.remove("monocle");
+    if legacy_focused.is_none() && legacy_monocle.is_none() {
+        return Ok(());
+    }
+
+    if !borders.contains_key("colors") {
+        borders.insert("colors", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let colors = borders
+        .get_mut("colors")
+        .and_then(|t| t.as_table_mut())
+        .ok_or_else(|| {
+            format!(
+                "{}: [borders.colors] is not a table -- cannot migrate",
+                path.display()
+            )
+        })?;
+
+    if let Some(item) = legacy_focused
+        && !colors.contains_key("focused")
+    {
+        colors.insert("focused", item);
+    }
+    if let Some(item) = legacy_monocle
+        && !colors.contains_key("monocle")
+    {
+        colors.insert("monocle", item);
+    }
+    Ok(())
 }
 
 /// Returns a non-clobbering backup path next to `path`.
@@ -793,6 +865,120 @@ mode = \"global\"
             "second backup should append .1 suffix, got {}",
             second.display()
         );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn migrates_legacy_border_colors() {
+        let path = unique_temp_path();
+        let original = "\
+[borders]
+width = 4
+focused = \"#ff0000\"
+monocle = \"#00ff00\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let migrated = migrate_config_if_needed(&path, original)
+            .unwrap()
+            .expect("migration should run");
+
+        // Re-parse and assert the values landed in the new shape.
+        let cfg: super::Config = toml::from_str(&migrated).unwrap();
+        assert_eq!(cfg.borders.width, 4);
+        assert_eq!(cfg.borders.colors.focused, "#ff0000");
+        assert_eq!(cfg.borders.colors.monocle, "#00ff00");
+
+        // Backup preserved.
+        let backup = path.with_extension("toml.pre-0.9.bak");
+        assert!(backup.exists());
+        assert_eq!(std::fs::read_to_string(&backup).unwrap(), original);
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn border_migration_is_idempotent() {
+        let path = unique_temp_path();
+        let original = "\
+[borders]
+width = 4
+focused = \"blue\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        migrate_config_if_needed(&path, original).unwrap().unwrap();
+        let after_first = std::fs::read_to_string(&path).unwrap();
+        let second = migrate_config_if_needed(&path, &after_first).unwrap();
+        assert!(second.is_none(), "second border migration must be a no-op");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn existing_border_colors_wins_over_legacy() {
+        let path = unique_temp_path();
+        let original = "\
+[borders]
+width = 4
+focused = \"red\"
+monocle = \"green\"
+
+[borders.colors]
+focused = \"blue\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let migrated = migrate_config_if_needed(&path, original).unwrap().unwrap();
+        let cfg: super::Config = toml::from_str(&migrated).unwrap();
+
+        // Existing nested focused wins over legacy.
+        assert_eq!(cfg.borders.colors.focused, "blue");
+        // Legacy monocle migrates because no nested value existed.
+        assert_eq!(cfg.borders.colors.monocle, "green");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn workspace_and_border_migrations_run_together() {
+        let path = unique_temp_path();
+        let original = "\
+[layout]
+gap = 8
+
+[layout.workspaces]
+1 = \"vertical-stack\"
+
+[borders]
+width = 4
+focused = \"#abcdef\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let migrated = migrate_config_if_needed(&path, original).unwrap().unwrap();
+
+        // Both legacy patterns are gone after migration.
+        assert!(!migrated.contains("[layout.workspaces]"));
+        assert!(migrated.contains("[workspaces.layouts]"));
+        assert!(migrated.contains("[borders.colors]"));
+        // Top-level `focused` under [borders] should not be there anymore;
+        // the only remaining `focused = ...` line lives under [borders.colors].
+        let bare_focused_lines = migrated
+            .lines()
+            .filter(|l| l.trim_start().starts_with("focused = "))
+            .count();
+        assert_eq!(
+            bare_focused_lines, 1,
+            "exactly one focused = line, under [borders.colors]"
+        );
+
+        // Only one backup created for the combined run.
+        let backup = path.with_extension("toml.pre-0.9.bak");
+        let collision = path.with_extension("toml.pre-0.9.bak.1");
+        assert!(backup.exists());
+        assert!(!collision.exists(), "single backup, not one per migration");
 
         cleanup(&path);
     }

--- a/crates/mosaico-core/src/config/mod.rs
+++ b/crates/mosaico-core/src/config/mod.rs
@@ -63,11 +63,11 @@ impl Config {
     /// Resolves border colors: empty → theme default, named → theme hex.
     fn resolve_borders(&mut self) {
         let theme = self.theme.resolve();
-        self.borders.focused = theme
-            .resolve_color(&self.borders.focused, theme.border_focused())
+        self.borders.colors.focused = theme
+            .resolve_color(&self.borders.colors.focused, theme.border_focused())
             .to_string();
-        self.borders.monocle = theme
-            .resolve_color(&self.borders.monocle, theme.border_monocle())
+        self.borders.colors.monocle = theme
+            .resolve_color(&self.borders.colors.monocle, theme.border_monocle())
             .to_string();
     }
 }

--- a/crates/mosaico-core/src/config/template_config.rs
+++ b/crates/mosaico-core/src/config/template_config.rs
@@ -43,7 +43,12 @@ mode = "per-monitor"
 width = 4
 # Corner style for borders and tiled windows: "square", "small", or "round".
 corner_style = "small"
-# Override theme border colors (hex or named: blue, green, mauve, etc.):
+
+# Override theme border colors. Both fields accept a hex color
+# ("#00b4d8") or a named theme color (blue, green, mauve, teal, etc.).
+# focused: color while a tiled layout is active
+# monocle: color while monocle mode is active
+# [borders.colors]
 # focused = "blue"
 # monocle = "green"
 

--- a/crates/mosaico-core/src/config/template_tests.rs
+++ b/crates/mosaico-core/src/config/template_tests.rs
@@ -40,8 +40,14 @@ fn config_template_matches_default_values() {
         defaults.mouse.focus_follows_mouse
     );
     // Border colors should resolve from the default Mocha theme.
-    assert_eq!(config.borders.focused, defaults.borders.focused);
-    assert_eq!(config.borders.monocle, defaults.borders.monocle);
+    assert_eq!(
+        config.borders.colors.focused,
+        defaults.borders.colors.focused
+    );
+    assert_eq!(
+        config.borders.colors.monocle,
+        defaults.borders.colors.monocle
+    );
 }
 
 #[test]

--- a/crates/mosaico-core/src/config/tests.rs
+++ b/crates/mosaico-core/src/config/tests.rs
@@ -16,23 +16,26 @@ fn validate_resolves_border_colors_from_theme() {
     config.validate();
 
     // Mocha defaults: Blue for focused, Green for monocle
-    assert_eq!(config.borders.focused, "#89b4fa");
-    assert_eq!(config.borders.monocle, "#a6e3a1");
+    assert_eq!(config.borders.colors.focused, "#89b4fa");
+    assert_eq!(config.borders.colors.monocle, "#a6e3a1");
 }
 
 #[test]
 fn explicit_border_color_overrides_theme() {
     let mut config = Config {
         borders: BorderConfig {
-            focused: "#ff0000".into(),
+            colors: BorderColors {
+                focused: "#ff0000".into(),
+                ..Default::default()
+            },
             ..Default::default()
         },
         ..Default::default()
     };
     config.validate();
 
-    assert_eq!(config.borders.focused, "#ff0000");
-    assert_eq!(config.borders.monocle, "#a6e3a1"); // still from theme
+    assert_eq!(config.borders.colors.focused, "#ff0000");
+    assert_eq!(config.borders.colors.monocle, "#a6e3a1"); // still from theme
 }
 
 #[test]
@@ -46,24 +49,26 @@ fn latte_theme_resolves_different_borders() {
     };
     config.validate();
 
-    assert_eq!(config.borders.focused, "#1e66f5");
-    assert_eq!(config.borders.monocle, "#40a02b");
+    assert_eq!(config.borders.colors.focused, "#1e66f5");
+    assert_eq!(config.borders.colors.monocle, "#40a02b");
 }
 
 #[test]
 fn named_color_in_border_resolves_to_hex() {
     let mut config = Config {
         borders: BorderConfig {
-            focused: "mauve".into(),
-            monocle: "teal".into(),
+            colors: BorderColors {
+                focused: "mauve".into(),
+                monocle: "teal".into(),
+            },
             ..Default::default()
         },
         ..Default::default()
     };
     config.validate();
 
-    assert_eq!(config.borders.focused, "#cba6f7");
-    assert_eq!(config.borders.monocle, "#94e2d5");
+    assert_eq!(config.borders.colors.focused, "#cba6f7");
+    assert_eq!(config.borders.colors.monocle, "#94e2d5");
 }
 
 #[test]

--- a/crates/mosaico-core/src/config/types.rs
+++ b/crates/mosaico-core/src/config/types.rs
@@ -117,10 +117,8 @@ pub struct BorderConfig {
     pub width: i32,
     /// Corner style for borders and tiled windows.
     pub corner_style: CornerStyle,
-    /// Hex color for the focused window border (e.g. "#00b4d8").
-    pub focused: String,
-    /// Hex color for the monocle mode border (e.g. "#2d6a4f").
-    pub monocle: String,
+    /// Border colors for focused windows in different layout modes.
+    pub colors: BorderColors,
 }
 
 /// Default border colors are empty — resolved from the theme in `validate()`.
@@ -129,10 +127,23 @@ impl Default for BorderConfig {
         Self {
             width: 4,
             corner_style: CornerStyle::default(),
-            focused: String::new(),
-            monocle: String::new(),
+            colors: BorderColors::default(),
         }
     }
+}
+
+/// Border colors for the focused window across layout modes.
+///
+/// Both fields hold a hex string (e.g. `"#00b4d8"`) or a named theme
+/// color. Empty strings resolve to the active theme's defaults during
+/// validation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BorderColors {
+    /// Focused-window border color while a tiled layout is active.
+    pub focused: String,
+    /// Focused-window border color while monocle mode is active.
+    pub monocle: String,
 }
 
 /// How a workspace switch is applied across monitors.

--- a/crates/mosaico-windows/src/tiling/focus.rs
+++ b/crates/mosaico-windows/src/tiling/focus.rs
@@ -69,9 +69,9 @@ impl TilingManager {
         };
         let is_monocle = mon.active_ws().monocle();
         let hex = if is_monocle {
-            &self.border_config.monocle
+            &self.border_config.colors.monocle
         } else {
-            &self.border_config.focused
+            &self.border_config.colors.focused
         };
         let color = Color::from_hex(hex).unwrap_or(Color {
             r: 0,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,8 +25,11 @@ All settings have sensible defaults, so configuration files are optional.
   `ratio: f64` (default 0.5), `hiding: HidingBehaviour` (default `Cloak`),
   `workspaces: HashMap<u32, String>` (per-workspace layout overrides)
 - `HidingBehaviour` (enum) -- `Cloak`, `Hide`, `Minimize`
-- `BorderConfig` -- `width: i32` (default 4), `focused: String` (default
-  `"#00b4d8"`), `monocle: String` (default `"#2d6a4f"`)
+- `BorderConfig` -- `width: i32` (default 4), `corner_style: CornerStyle`,
+  `colors: BorderColors`
+- `BorderColors` -- `focused: String` and `monocle: String`. Both default
+  to empty strings and resolve from the active theme (`"#89b4fa"` blue and
+  `"#a6e3a1"` green for Mocha)
 - `LogConfig` -- `enabled: bool` (default false), `level: String` (default
   `"info"`), `max_file_mb: u64` (default 10)
 - `WindowRule` -- `match_class: Option<String>`, `match_title: Option<String>`,
@@ -65,8 +68,10 @@ mode = "per-monitor"  # "per-monitor" (default) or "global"
 [borders]
 width = 4              # Border thickness in pixels (0-32)
 corner_style = "small" # "square", "small", or "round"
-focused = "#00b4d8"    # Hex color for focused window
-monocle = "#2d6a4f"    # Hex color for monocle mode
+
+[borders.colors]
+focused = "#00b4d8"    # Color of the focused window in tiled layouts
+monocle = "#2d6a4f"    # Color of the focused window in monocle mode
 
 [theme]
 flavor = "mocha"   # Catppuccin flavor: latte, frappe, macchiato, mocha

--- a/docs/focus-border.md
+++ b/docs/focus-border.md
@@ -85,6 +85,8 @@ In `config.toml`:
 [borders]
 width = 4              # Border thickness in pixels (0-32)
 corner_style = "small" # "square", "small", or "round"
+
+[borders.colors]
 focused = "#00b4d8"    # Color for normal focused window
 monocle = "#2d6a4f"    # Color when monocle mode is active
 ```

--- a/website/src/guide/configuration.md
+++ b/website/src/guide/configuration.md
@@ -41,8 +41,10 @@ mode = "per-monitor"
 [borders]
 width = 4              # Border thickness in pixels (0-32)
 corner_style = "small" # "square", "small", or "round"
-focused = "#00b4d8"    # Hex color for focused window
-monocle = "#2d6a4f"    # Hex color for monocle mode
+
+[borders.colors]
+focused = "#00b4d8"    # Color of the focused window in tiled layouts
+monocle = "#2d6a4f"    # Color of the focused window in monocle mode
 
 [theme]
 flavor = "mocha"   # Catppuccin flavor: latte, frappe, macchiato, mocha

--- a/website/src/guide/focus-border.md
+++ b/website/src/guide/focus-border.md
@@ -11,8 +11,10 @@ Border settings are in `config.toml`:
 [borders]
 width = 4              # Border thickness in pixels (0-32)
 corner_style = "small" # "square", "small", or "round"
-focused = "#00b4d8"    # Color for focused window
-monocle = "#2d6a4f"    # Color for monocle mode
+
+[borders.colors]
+focused = "#00b4d8"    # Color for focused window in tiled layouts
+monocle = "#2d6a4f"    # Color for focused window in monocle mode
 ```
 
 - **width** -- thickness of the border in pixels. Set to `0` to disable
@@ -27,9 +29,9 @@ monocle = "#2d6a4f"    # Color for monocle mode
   | `"small"` | Subtle rounding (8 px) | `ROUNDSMALL` (~4 px) |
   | `"round"` | Standard rounding (16 px) | `ROUND` (~8 px) |
 
-- **focused** -- the border color during normal tiling. Accepts hex colors
-  or named Catppuccin colors (see [Theming](theming.md)).
-- **monocle** -- the border color when monocle mode is active.
+- **borders.colors.focused** -- the border color during normal tiling.
+  Accepts hex colors or named Catppuccin colors (see [Theming](theming.md)).
+- **borders.colors.monocle** -- the border color when monocle mode is active.
 
 ## Behavior
 
@@ -44,7 +46,7 @@ monocle = "#2d6a4f"    # Color for monocle mode
 With a theme active, you can use named colors:
 
 ```toml
-[borders]
+[borders.colors]
 focused = "blue"
 monocle = "green"
 ```
@@ -52,4 +54,4 @@ monocle = "green"
 ## Hot-Reload
 
 Border settings are hot-reloaded. Changes to `width`, `corner_style`,
-`focused`, and `monocle` colors take effect immediately.
+and the `[borders.colors]` entries take effect immediately.

--- a/website/src/guide/theming.md
+++ b/website/src/guide/theming.md
@@ -87,7 +87,7 @@ accent = "blue"
 Using named colors for borders in `config.toml`:
 
 ```toml
-[borders]
+[borders.colors]
 focused = "blue"
 monocle = "green"
 ```


### PR DESCRIPTION
## Summary

Group the two border colors under a dedicated `[borders.colors]` sub-table so the schema reads more naturally (both fields are colors of the *focused* window in different layout modes) and so the section has room to grow (e.g. a future `unfocused` color) without another breaking change.

**Old shape**

```toml
[borders]
width = 4
corner_style = "small"
focused = "blue"
monocle = "green"
```

**New shape**

```toml
[borders]
width = 4
corner_style = "small"

[borders.colors]
focused = "blue"
monocle = "green"
```

## Schema

- New `BorderColors { focused, monocle }` sub-struct in `mosaico-core`.
- `BorderConfig.focused` / `.monocle` removed; replaced by `colors: BorderColors`.
- All read sites updated: `config/mod.rs::resolve_borders`, `tiling/focus.rs`, and existing tests.
- `mosaico init` template now emits `[borders.colors]` as a commented example with both field semantics documented.

## Migration

- Existing `migrate_config_if_needed` extended to also detect top-level `focused` / `monocle` keys under `[borders]` and move them into a new `[borders.colors]` sub-table. Comments and formatting are preserved via `toml_edit`. Idempotent.
- Both migrations (workspaces and borders) share a single backup file and a single rewrite pass.
- 4 new unit tests: legacy detection + move, idempotence, conflict policy (existing `[borders.colors]` wins), and combined workspaces+borders migration in one pass.

## Docs

- `docs/configuration.md`, `docs/focus-border.md`, `website/src/guide/configuration.md`, `website/src/guide/focus-border.md`, and `website/src/guide/theming.md` all updated to reference `[borders.colors]`.
- `docs/configuration.md` "Key Types" entry rewritten to include the new `BorderColors` struct.

## Breaking change

`borders.focused` and `borders.monocle` moved to `borders.colors.focused` and `borders.colors.monocle`. Existing users are auto-migrated on next daemon start (with a backup at `config.toml.pre-0.9.bak`).

## Test plan

- [ ] Existing install with legacy `[borders] focused = "..."` / `monocle = "..."`: start the daemon, confirm `Info: migrated config keys ([borders] focused/monocle -> [borders.colors])` is logged, confirm the file is rewritten with the values now under `[borders.colors]`, confirm a backup is saved.
- [ ] Re-run the daemon: no second migration log, no extra backup file.
- [ ] Install with both legacy and new sections present: existing `[borders.colors]` wins, legacy keys are removed, no override.
- [ ] Combined upgrade scenario: a config with both `[layout.workspaces]` and legacy `[borders] focused/monocle` migrates both in one pass with a single backup.
- [ ] After migration, focus changes color when toggling monocle (`Alt+T`).
- [ ] Editing `[borders.colors].focused` and saving hot-reloads the color without restart.
