### PR TITLE
fix(workspaces): deserialize [workspaces.layouts] string keys as u8

### DIFF
--- a/crates/mosaico-core/src/config/tests.rs
+++ b/crates/mosaico-core/src/config/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::layout::LayoutKind;
 
 #[test]
 fn default_config_has_expected_values() {
@@ -91,6 +92,85 @@ fn partial_toml_uses_defaults_for_missing_sections() {
     // Assert
     assert_eq!(config.layout.gap, 16);
     assert_eq!(config.layout.ratio, 0.5);
+}
+
+#[test]
+fn workspaces_layouts_parses_string_keys_as_u8() {
+    // Arrange
+    let toml_str = r#"
+[workspaces.layouts]
+1 = "vertical-stack"
+3 = "three-column"
+"#;
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    assert_eq!(
+        config.workspaces.layouts.get(&1).copied(),
+        Some(LayoutKind::VerticalStack)
+    );
+    assert_eq!(
+        config.workspaces.layouts.get(&3).copied(),
+        Some(LayoutKind::ThreeColumn)
+    );
+    assert!(!config.workspaces.layouts.contains_key(&2));
+}
+
+#[test]
+fn workspaces_layouts_drops_out_of_range_keys() {
+    // Arrange: 0 and 9 are out of the valid 1..=8 range; 2 is valid.
+    let toml_str = r#"
+[workspaces.layouts]
+0 = "bsp"
+2 = "vertical-stack"
+9 = "three-column"
+"#;
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    assert!(!config.workspaces.layouts.contains_key(&0));
+    assert!(!config.workspaces.layouts.contains_key(&9));
+    assert_eq!(
+        config.workspaces.layouts.get(&2).copied(),
+        Some(LayoutKind::VerticalStack)
+    );
+}
+
+#[test]
+fn workspaces_layouts_drops_non_numeric_keys() {
+    // Arrange: a non-numeric key should be skipped without failing the
+    // whole parse.
+    let toml_str = r#"
+[workspaces.layouts]
+abc = "bsp"
+1 = "three-column"
+"#;
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    assert_eq!(config.workspaces.layouts.len(), 1);
+    assert_eq!(
+        config.workspaces.layouts.get(&1).copied(),
+        Some(LayoutKind::ThreeColumn)
+    );
+}
+
+#[test]
+fn workspaces_layouts_missing_section_is_empty_default() {
+    // Arrange: no [workspaces.layouts] section at all.
+    let toml_str = "[layout]\ngap = 8\n";
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    assert!(config.workspaces.layouts.is_empty());
 }
 
 #[test]

--- a/crates/mosaico-core/src/config/types.rs
+++ b/crates/mosaico-core/src/config/types.rs
@@ -4,8 +4,9 @@
 /// across the configuration subsystem.
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
+use crate::action::MAX_WORKSPACES;
 use crate::layout::LayoutKind;
 
 /// Layout algorithm settings.
@@ -42,8 +43,45 @@ impl Default for LayoutConfig {
 pub struct WorkspacesConfig {
     /// How a workspace switch is applied across monitors.
     pub mode: WorkspaceMode,
-    /// Per-workspace layout overrides (workspace number 1–8 → layout).
+    /// Per-workspace layout overrides (workspace number 1-8 to layout).
+    ///
+    /// TOML keys are always strings, so we deserialize via a helper that
+    /// parses each key as a `u8` and silently drops keys outside the
+    /// valid `1..=MAX_WORKSPACES` range (logging a warning for each).
+    /// This lets users write `[workspaces.layouts]\n1 = "vertical-stack"`
+    /// while the internal lookup remains `u8`-keyed.
+    #[serde(deserialize_with = "deserialize_layouts_map")]
     pub layouts: HashMap<u8, LayoutKind>,
+}
+
+/// Deserializes a TOML table whose string keys represent workspace
+/// numbers (`1`..=`MAX_WORKSPACES`). Invalid keys are dropped with a
+/// warning so a typo on one workspace never fails the whole config.
+fn deserialize_layouts_map<'de, D>(deserializer: D) -> Result<HashMap<u8, LayoutKind>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, LayoutKind> = HashMap::deserialize(deserializer)?;
+    let mut out = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        match key.parse::<u8>() {
+            Ok(n) if (1..=MAX_WORKSPACES).contains(&n) => {
+                out.insert(n, value);
+            }
+            Ok(n) => {
+                eprintln!(
+                    "Warning: ignoring [workspaces.layouts] entry for workspace {n}: \
+                     must be in 1..={MAX_WORKSPACES}"
+                );
+            }
+            Err(_) => {
+                eprintln!(
+                    "Warning: ignoring [workspaces.layouts] entry with non-numeric key {key:?}"
+                );
+            }
+        }
+    }
+    Ok(out)
 }
 
 /// How windows are hidden when switching away from their workspace.


### PR DESCRIPTION
## Summary

`WorkspacesConfig.layouts` was typed as `HashMap<u8, LayoutKind>`, but TOML keys are always strings, so the toml/serde stack rejected every user config that actually used the field with:

```
invalid type: string "1", expected u8
```

The field had been silently broken since it was introduced (originally as `LayoutConfig.workspaces`, later moved to `WorkspacesConfig.layouts` in #9). Nobody noticed because no end-to-end parse test ever exercised it.

## Fix

Add a `serde(deserialize_with = "deserialize_layouts_map")` helper that:

1. Reads the TOML table into an intermediate `HashMap<String, LayoutKind>`.
2. Parses each key as `u8`.
3. Inserts only keys in the valid `1..=MAX_WORKSPACES` range.
4. Drops out-of-range and non-numeric keys with a `Warning:` log line so a typo on a single entry never fails the whole config load.

The internal field type stays `HashMap<u8, LayoutKind>`, so every call site (`TilingManager::new`, etc.) is unchanged. `Serialize` is unaffected and round-trips fine via the default `HashMap` impl.

## Tests

Four new unit tests in `config/tests.rs`:

- `workspaces_layouts_parses_string_keys_as_u8` — round-trips `1 = "vertical-stack"` / `3 = "three-column"` through TOML and asserts the values land at the right `u8` keys.
- `workspaces_layouts_drops_out_of_range_keys` — `0` and `9` are dropped; `2` still parses.
- `workspaces_layouts_drops_non_numeric_keys` — `abc = "bsp"` is skipped without failing the surrounding config parse.
- `workspaces_layouts_missing_section_is_empty_default` — omitting the section yields an empty map (the existing `#[serde(default)]` still composes correctly with `deserialize_with`).

All 211 lib tests pass locally; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Test plan

- [ ] Add `[workspaces.layouts]\n1 = "vertical-stack"` to `~/.config/mosaico/config.toml`. Restart the daemon. Confirm workspace 1 starts on VerticalStack.
- [ ] Add an out-of-range entry like `9 = "bsp"`. Restart. Confirm a `Warning: ignoring [workspaces.layouts] entry for workspace 9` line is logged and the daemon still starts.
- [ ] Add a non-numeric entry like `abc = "bsp"`. Restart. Confirm a `Warning: ignoring [workspaces.layouts] entry with non-numeric key "abc"` line is logged.
- [ ] Remove the `[workspaces.layouts]` section entirely. Confirm the daemon starts and uses `layout.default` for every workspace.
