### PR TITLE
feat(borders): draw colored borders around unfocused tiled windows

### DIFF
--- a/crates/mosaico-core/src/config/loader.rs
+++ b/crates/mosaico-core/src/config/loader.rs
@@ -277,7 +277,37 @@ pub fn merge_missing_config_sections() {
         Ok(false) => {}
         Err(e) => eprintln!("Warning: {e}"),
     }
+
+    match append_missing_unfocused_border_hint(&path) {
+        Ok(true) => eprintln!(
+            "Info: appended unfocused border hint to {} (new in this version)",
+            path.display()
+        ),
+        Ok(false) => {}
+        Err(e) => eprintln!("Warning: {e}"),
+    }
 }
+
+/// Comment block appended to `config.toml` when the file has no
+/// reference to the `unfocused` border color, so existing users
+/// discover the new option without having to read release notes.
+const UNFOCUSED_BORDER_HINT_SNIPPET: &str = r##"
+# Added automatically -- new in this version of mosaico
+# The `unfocused` color under [borders.colors] sets the border drawn
+# around tiled windows that do not currently have focus. Recognized
+# values:
+#   ""           use the active theme's muted gray default (Mocha:
+#                #6c7086). This is the default when the field is
+#                absent.
+#   "none"       disable unfocused borders entirely; only the focused
+#                window will get a border.
+#   "#RRGGBB"    explicit hex color.
+#   "blue"       any named theme color (mauve, teal, lavender, etc.).
+#
+# Example:
+#   [borders.colors]
+#   unfocused = "none"
+"##;
 
 /// Path-pure helper for [`merge_missing_config_sections`]: returns
 /// `Ok(true)` when an append happened, `Ok(false)` when the file already
@@ -310,6 +340,90 @@ fn append_missing_workspaces_section(path: &Path) -> Result<bool, String> {
     f.write_all(to_append.as_bytes())
         .map_err(|e| format!("could not append to {}: {e}", path.display()))?;
     Ok(true)
+}
+
+/// Adds a documented `unfocused` field to the user's config so the
+/// new option is discoverable.
+///
+/// Two strategies, in order:
+/// 1. If `[borders.colors]` is an active table, insert `unfocused = ""`
+///    into it with a leading comment. Empty string preserves current
+///    behavior (theme-default muted gray).
+/// 2. Otherwise (no active table, or the table is commented out), if
+///    the file does not already mention `unfocused`, append a
+///    standalone comment block at the end of the file.
+///
+/// Both paths are idempotent: a second run finds the key (or the
+/// substring) already present and does nothing.
+fn append_missing_unfocused_border_hint(path: &Path) -> Result<bool, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+
+    if let Some(updated) = insert_unfocused_into_active_section(&content)? {
+        std::fs::write(path, updated)
+            .map_err(|e| format!("could not write {}: {e}", path.display()))?;
+        return Ok(true);
+    }
+
+    // Fall back to the comment-only hint when there is no active
+    // [borders.colors] section to extend. Skip when any reference to
+    // `unfocused` already exists (active key, comment, prior hint).
+    if content.contains("unfocused") {
+        return Ok(false);
+    }
+
+    let mut to_append = String::new();
+    if !content.ends_with('\n') {
+        to_append.push('\n');
+    }
+    to_append.push_str(UNFOCUSED_BORDER_HINT_SNIPPET);
+
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("could not open {} for appending: {e}", path.display()))?;
+    f.write_all(to_append.as_bytes())
+        .map_err(|e| format!("could not append to {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+/// Inline comment placed above the inserted `unfocused` key. Kept on
+/// its own constant so the tests can pin the wording without growing
+/// the inline path.
+const UNFOCUSED_INLINE_PREFIX: &str = "\n\
+    # Color drawn around unfocused tiled windows.\n\
+    # \"none\" disables unfocused borders; \"\" (empty) uses the\n\
+    # theme default (muted gray); a hex code or named theme color\n\
+    # works too.\n";
+
+/// If `content` has an active `[borders.colors]` table that is missing
+/// the `unfocused` key, returns the rewritten file contents with the
+/// key inserted. Returns `Ok(None)` when no edit is needed.
+fn insert_unfocused_into_active_section(content: &str) -> Result<Option<String>, String> {
+    let mut doc: toml_edit::DocumentMut =
+        content.parse().map_err(|e| format!("parse error: {e}"))?;
+
+    let Some(colors) = doc
+        .get_mut("borders")
+        .and_then(|t| t.as_table_mut())
+        .and_then(|t| t.get_mut("colors"))
+        .and_then(|t| t.as_table_mut())
+    else {
+        return Ok(None);
+    };
+
+    if colors.contains_key("unfocused") {
+        return Ok(None);
+    }
+
+    colors.insert("unfocused", toml_edit::value(""));
+    if let Some(mut key) = colors.key_mut("unfocused") {
+        key.leaf_decor_mut()
+            .set_prefix(toml_edit::RawString::from(UNFOCUSED_INLINE_PREFIX));
+    }
+
+    Ok(Some(doc.to_string()))
 }
 
 /// Tries to load and parse `keybindings.toml`.
@@ -845,6 +959,152 @@ mode = \"global\"
         // `gap = 8`.
         assert!(on_disk.contains("gap = 8\n"));
         assert!(on_disk.contains("[workspaces]"));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unfocused_inserted_inline_when_borders_colors_active() {
+        let path = unique_temp_path();
+        // Active [borders.colors] with focused/monocle but no unfocused.
+        let original = "\
+[borders]
+width = 4
+
+[borders.colors]
+focused = \"blue\"
+monocle = \"red\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let updated = append_missing_unfocused_border_hint(&path).unwrap();
+        assert!(updated, "should insert unfocused when section is active");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+
+        // Round-trips through serde with the new field set to "".
+        let cfg: super::Config = toml::from_str(&on_disk).unwrap();
+        assert_eq!(cfg.borders.colors.focused, "blue");
+        assert_eq!(cfg.borders.colors.monocle, "red");
+        assert_eq!(cfg.borders.colors.unfocused, "");
+
+        // The key sits inside [borders.colors] alongside focused and
+        // monocle, not as an orphan block at the end of the file.
+        let colors_idx = on_disk.find("[borders.colors]").unwrap();
+        let unfocused_idx = on_disk.find("unfocused").unwrap();
+        assert!(unfocused_idx > colors_idx);
+
+        // The leading comment block survived the rewrite.
+        assert!(on_disk.contains("Color drawn around unfocused tiled windows."));
+        // No fallback bottom hint was added.
+        assert!(!on_disk.contains("Added automatically"));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unfocused_inline_insertion_is_idempotent() {
+        let path = unique_temp_path();
+        let original = "\
+[borders.colors]
+focused = \"blue\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        assert!(append_missing_unfocused_border_hint(&path).unwrap());
+        let after_first = std::fs::read_to_string(&path).unwrap();
+
+        assert!(!append_missing_unfocused_border_hint(&path).unwrap());
+        let after_second = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after_first, after_second);
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn appends_unfocused_border_hint_when_section_missing() {
+        let path = unique_temp_path();
+        // No [borders.colors] section at all; the section in the file
+        // is commented out.
+        let original = "\
+[borders]
+width = 4
+corner_style = \"small\"
+# [borders.colors]
+# focused = \"blue\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let appended = append_missing_unfocused_border_hint(&path).unwrap();
+        assert!(appended, "should append bottom hint when no active section");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.starts_with(original), "existing content preserved");
+        assert!(on_disk.contains("unfocused"));
+        assert!(on_disk.contains("\"none\""));
+        // Existing [borders.colors] is still commented out.
+        assert!(!on_disk.contains("\nfocused = \"blue\""));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unfocused_bottom_hint_is_idempotent() {
+        let path = unique_temp_path();
+        let original = "[borders]\nwidth = 4\n";
+        std::fs::write(&path, original).unwrap();
+
+        assert!(append_missing_unfocused_border_hint(&path).unwrap());
+        let after_first = std::fs::read_to_string(&path).unwrap();
+
+        assert!(!append_missing_unfocused_border_hint(&path).unwrap());
+        let after_second = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after_first, after_second);
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unfocused_hint_not_appended_when_user_already_set_it() {
+        let path = unique_temp_path();
+        let original = "\
+[borders.colors]
+unfocused = \"#deadbe\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let appended = append_missing_unfocused_border_hint(&path).unwrap();
+        assert!(
+            !appended,
+            "active 'unfocused' key should suppress all updates"
+        );
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(on_disk, original, "file untouched when user already set it");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unfocused_hint_not_appended_when_template_already_mentions_it() {
+        let path = unique_temp_path();
+        // Mirrors the new commented template generated by `mosaico init`.
+        let original = "\
+[borders]
+width = 4
+
+# [borders.colors]
+# focused = \"blue\"
+# monocle = \"green\"
+# unfocused = \"none\"
+";
+        std::fs::write(&path, original).unwrap();
+
+        let appended = append_missing_unfocused_border_hint(&path).unwrap();
+        assert!(
+            !appended,
+            "commented template mentioning 'unfocused' should suppress the hint"
+        );
 
         cleanup(&path);
     }

--- a/crates/mosaico-core/src/config/mod.rs
+++ b/crates/mosaico-core/src/config/mod.rs
@@ -60,7 +60,12 @@ impl Config {
         self.borders.width = self.borders.width.clamp(0, 32);
     }
 
-    /// Resolves border colors: empty → theme default, named → theme hex.
+    /// Resolves border colors: empty -> theme default, named -> theme hex.
+    ///
+    /// `unfocused` accepts a sentinel value of `BorderColors::NONE`
+    /// ("none") meaning "do not draw borders around unfocused windows";
+    /// the sentinel is preserved verbatim so downstream code can detect
+    /// it via `BorderColors::unfocused_enabled()`.
     fn resolve_borders(&mut self) {
         let theme = self.theme.resolve();
         self.borders.colors.focused = theme
@@ -69,6 +74,11 @@ impl Config {
         self.borders.colors.monocle = theme
             .resolve_color(&self.borders.colors.monocle, theme.border_monocle())
             .to_string();
+        if self.borders.colors.unfocused != BorderColors::NONE {
+            self.borders.colors.unfocused = theme
+                .resolve_color(&self.borders.colors.unfocused, theme.border_unfocused())
+                .to_string();
+        }
     }
 }
 

--- a/crates/mosaico-core/src/config/template_config.rs
+++ b/crates/mosaico-core/src/config/template_config.rs
@@ -44,13 +44,17 @@ width = 4
 # Corner style for borders and tiled windows: "square", "small", or "round".
 corner_style = "small"
 
-# Override theme border colors. Both fields accept a hex color
+# Override theme border colors. Each field accepts a hex color
 # ("#00b4d8") or a named theme color (blue, green, mauve, teal, etc.).
-# focused: color while a tiled layout is active
-# monocle: color while monocle mode is active
+# focused:   color while a tiled layout is active
+# monocle:   color while monocle mode is active
+# unfocused: color drawn around unfocused tiled windows. Set to "none"
+#            to disable unfocused borders entirely; leave empty (or
+#            unset) to use the theme's muted gray default.
 # [borders.colors]
 # focused = "blue"
 # monocle = "green"
+# unfocused = "none"
 
 [mouse]
 # Move the cursor to the center of the focused window on keyboard navigation.

--- a/crates/mosaico-core/src/config/tests.rs
+++ b/crates/mosaico-core/src/config/tests.rs
@@ -61,6 +61,7 @@ fn named_color_in_border_resolves_to_hex() {
             colors: BorderColors {
                 focused: "mauve".into(),
                 monocle: "teal".into(),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -159,6 +160,57 @@ abc = "bsp"
         config.workspaces.layouts.get(&1).copied(),
         Some(LayoutKind::ThreeColumn)
     );
+}
+
+#[test]
+fn unfocused_border_defaults_to_theme_when_unset() {
+    // A bare config with no [borders.colors] section should resolve
+    // unfocused to the Mocha theme's muted gray (Overlay0).
+    let mut config = Config::default();
+    config.validate();
+    assert_eq!(config.borders.colors.unfocused, "#6c7086");
+    assert!(config.borders.colors.unfocused_enabled());
+}
+
+#[test]
+fn unfocused_none_sentinel_disables_unfocused_borders() {
+    // The literal value "none" is preserved verbatim through validation
+    // and reported as disabled.
+    let toml_str = r#"
+[borders.colors]
+unfocused = "none"
+"#;
+    let mut config: Config = toml::from_str(toml_str).unwrap();
+    config.validate();
+    assert_eq!(config.borders.colors.unfocused, "none");
+    assert!(!config.borders.colors.unfocused_enabled());
+}
+
+#[test]
+fn explicit_unfocused_hex_passes_through_unchanged() {
+    let toml_str = r##"
+[borders.colors]
+unfocused = "#deadbe"
+"##;
+    let mut config: Config = toml::from_str(toml_str).unwrap();
+    config.validate();
+    assert_eq!(config.borders.colors.unfocused, "#deadbe");
+    assert!(config.borders.colors.unfocused_enabled());
+}
+
+#[test]
+fn named_unfocused_color_resolves_via_theme_palette() {
+    // Named accent colors are resolved through the active theme.
+    // Mocha's mauve is a known Catppuccin hex.
+    let toml_str = r#"
+[borders.colors]
+unfocused = "mauve"
+"#;
+    let mut config: Config = toml::from_str(toml_str).unwrap();
+    config.validate();
+    // Mocha mauve = #cba6f7
+    assert_eq!(config.borders.colors.unfocused, "#cba6f7");
+    assert!(config.borders.colors.unfocused_enabled());
 }
 
 #[test]

--- a/crates/mosaico-core/src/config/theme.rs
+++ b/crates/mosaico-core/src/config/theme.rs
@@ -101,6 +101,20 @@ impl Theme {
         }
     }
 
+    /// Returns the unfocused window border color (Catppuccin Overlay0).
+    ///
+    /// Chosen to be visible but understated against each theme's base
+    /// background, so unfocused tile boundaries remain readable
+    /// without competing with the focused-window highlight.
+    pub fn border_unfocused(self) -> &'static str {
+        match self {
+            Self::Mocha => "#6c7086",
+            Self::Macchiato => "#6e738d",
+            Self::Frappe => "#737994",
+            Self::Latte => "#9ca0b0",
+        }
+    }
+
     /// Resolves a named Catppuccin color (e.g. "blue", "green") to its
     /// hex value for this theme. Returns `None` for unknown names.
     ///
@@ -216,6 +230,25 @@ mod tests {
         assert_eq!(Theme::Mocha.border_monocle(), "#a6e3a1");
         assert_eq!(Theme::Latte.border_focused(), "#1e66f5");
         assert_eq!(Theme::Latte.border_monocle(), "#40a02b");
+    }
+
+    #[test]
+    fn unfocused_border_is_distinct_per_theme() {
+        // Each theme picks a muted gray drawn from its own palette
+        // (Catppuccin Overlay0).
+        let cases = [
+            (Theme::Mocha, "#6c7086"),
+            (Theme::Macchiato, "#6e738d"),
+            (Theme::Frappe, "#737994"),
+            (Theme::Latte, "#9ca0b0"),
+        ];
+        for (theme, hex) in cases {
+            assert_eq!(theme.border_unfocused(), hex, "theme {theme:?}");
+            // Sanity: distinct from the theme's focused and monocle
+            // colors so the unfocused state is visually different.
+            assert_ne!(theme.border_unfocused(), theme.border_focused());
+            assert_ne!(theme.border_unfocused(), theme.border_monocle());
+        }
     }
 
     #[test]

--- a/crates/mosaico-core/src/config/types.rs
+++ b/crates/mosaico-core/src/config/types.rs
@@ -170,11 +170,13 @@ impl Default for BorderConfig {
     }
 }
 
-/// Border colors for the focused window across layout modes.
+/// Border colors across focus and layout states.
 ///
-/// Both fields hold a hex string (e.g. `"#00b4d8"`) or a named theme
+/// Each field holds a hex string (e.g. `"#00b4d8"`) or a named theme
 /// color. Empty strings resolve to the active theme's defaults during
-/// validation.
+/// validation. The `unfocused` field also accepts the literal value
+/// `"none"` to disable rendering borders around unfocused windows
+/// (only the focused window will then have a border).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BorderColors {
@@ -182,6 +184,21 @@ pub struct BorderColors {
     pub focused: String,
     /// Focused-window border color while monocle mode is active.
     pub monocle: String,
+    /// Border color drawn around unfocused tiled windows. Empty string
+    /// uses the theme default (a muted gray); `"none"` disables
+    /// unfocused borders entirely.
+    pub unfocused: String,
+}
+
+impl BorderColors {
+    /// Sentinel value for `unfocused` meaning "no border around
+    /// unfocused windows".
+    pub const NONE: &'static str = "none";
+
+    /// Returns true when unfocused borders should be rendered.
+    pub fn unfocused_enabled(&self) -> bool {
+        self.unfocused != Self::NONE
+    }
 }
 
 /// How a workspace switch is applied across monitors.

--- a/crates/mosaico-windows/src/config_watcher.rs
+++ b/crates/mosaico-windows/src/config_watcher.rs
@@ -24,8 +24,9 @@ const WAIT_TIMEOUT_MS: u32 = 5000;
 
 /// A validated config reload ready to be applied.
 pub enum ConfigReload {
-    /// Layout and border settings changed.
-    Config(Config),
+    /// Layout and border settings changed. Boxed because `Config` is
+    /// substantially larger than the other variants.
+    Config(Box<Config>),
     /// Window rules changed.
     Rules(Vec<WindowRule>),
     /// Bar configuration changed.
@@ -108,7 +109,7 @@ fn check_and_reload(
             match config::try_load() {
                 Ok(cfg) => {
                     mosaico_core::log_info!("config.toml changed, reloading");
-                    if tx.send(ConfigReload::Config(cfg)).is_err() {
+                    if tx.send(ConfigReload::Config(Box::new(cfg))).is_err() {
                         return true;
                     }
                 }

--- a/crates/mosaico-windows/src/tiling/focus.rs
+++ b/crates/mosaico-windows/src/tiling/focus.rs
@@ -1,12 +1,22 @@
-//! Focus management and border overlay for the tiling manager.
+//! Focus management and per-window border overlays for the tiling manager.
 
+use mosaico_core::Rect;
+use mosaico_core::config::BorderColors;
 use mosaico_core::window::Window as WindowTrait;
 use windows::Win32::UI::WindowsAndMessaging::SetCursorPos;
 
-use crate::border::Color;
+use crate::border::{Border, Color};
 use crate::window::Window;
 
 use super::TilingManager;
+
+/// Fallback border color used when a configured value fails to parse
+/// as a hex string. Matches the historical default focused color.
+const FALLBACK_COLOR: Color = Color {
+    r: 0,
+    g: 0xB4,
+    b: 0xD8,
+};
 
 impl TilingManager {
     /// Moves the cursor to the center of the given window.
@@ -46,67 +56,149 @@ impl TilingManager {
         }
     }
 
-    pub(super) fn update_border(&self) {
-        let Some(border) = &self.border else {
-            return;
-        };
-        let Some(hwnd) = self.focused_window else {
-            border.hide();
-            return;
-        };
-        let window = Window::from_raw(hwnd);
-        // Hide the border when the focused window is maximized or minimized —
-        // the border would be invisible or orphaned on screen.
-        if window.is_maximized() || window.is_minimized() {
-            border.hide();
-            return;
-        }
-        let Ok(rect) = window.rect() else {
-            return;
-        };
-        let Some(mon) = self.monitors.get(self.focused_monitor) else {
-            return;
-        };
-        let is_monocle = mon.active_ws().monocle();
-        let hex = if is_monocle {
-            &self.border_config.colors.monocle
-        } else {
-            &self.border_config.colors.focused
-        };
-        let color = Color::from_hex(hex).unwrap_or(Color {
-            r: 0,
-            g: 0xB4,
-            b: 0xD8,
-        });
-        mosaico_core::log_debug!(
-            "border.show 0x{:X} at ({},{} {}x{}) mon={}",
-            hwnd,
-            rect.x,
-            rect.y,
-            rect.width,
-            rect.height,
-            self.focused_monitor
-        );
-        border.show(
-            &rect,
-            color,
-            self.border_config.width,
-            self.border_config.corner_style.border_radius(),
-            window.hwnd(),
-        );
-    }
-
-    pub(super) fn hide_border(&self) {
-        if let Some(border) = &self.border {
-            border.hide();
-        }
-    }
-
-    /// Re-positions the focus border to match the current window rect.
+    /// Refreshes every border overlay to match the current layout and
+    /// focus state.
     ///
-    /// Call after work areas change (e.g. bar adjustment at startup) so
-    /// the border reflects the final window position, not the pre-adjustment one.
-    pub fn refresh_border(&self) {
+    /// - Creates borders for newly tiled windows on any monitor's
+    ///   active workspace.
+    /// - Drops borders for windows that have left an active workspace.
+    /// - Recolors the focused window with the focused (or monocle)
+    ///   color, others with the unfocused color.
+    /// - Hides borders that should not be visible (e.g. neighbors of a
+    ///   maximized focused window, every non-monocle window in monocle
+    ///   mode, all unfocused windows when unfocused borders are
+    ///   disabled).
+    pub(super) fn update_border(&mut self) {
+        // Snapshot the current active-workspace contents per monitor so
+        // we can compute color/visibility decisions without re-borrowing
+        // self while we render.
+        let visible: Vec<(usize, usize, mosaico_core::Rect)> = self.collect_visible_tiles();
+
+        let visible_set: std::collections::HashSet<usize> =
+            visible.iter().map(|(h, _, _)| *h).collect();
+
+        // Drop borders whose owning window is no longer visible. Drop
+        // runs `DestroyWindow`, which atomically hides + cleans up.
+        self.borders.retain(|hwnd, _| visible_set.contains(hwnd));
+
+        let focused_window = self.focused_window;
+        let focused_monitor = self.focused_monitor;
+        let focused_is_maximized = focused_window
+            .map(|h| Window::from_raw(h).is_maximized())
+            .unwrap_or(false);
+        let focused_monocle = self
+            .monitors
+            .get(focused_monitor)
+            .is_some_and(|m| m.active_ws().monocle());
+
+        let unfocused_enabled = self.border_config.colors.unfocused_enabled();
+        let width = self.border_config.width;
+        let radius = self.border_config.corner_style.border_radius();
+
+        let focused_color = parse_color(&self.border_config.colors.focused);
+        let monocle_color = parse_color(&self.border_config.colors.monocle);
+        let unfocused_color = parse_color(&self.border_config.colors.unfocused);
+
+        for (hwnd, mon_idx, rect) in visible {
+            let window = Window::from_raw(hwnd);
+            // Skip windows that are visually absent: minimized windows
+            // and any window covered by a focused-maximized neighbor on
+            // the same monitor.
+            if window.is_minimized()
+                || (focused_is_maximized
+                    && Some(hwnd) != focused_window
+                    && mon_idx == focused_monitor)
+            {
+                if let Some(border) = self.borders.get(&hwnd) {
+                    border.hide();
+                }
+                continue;
+            }
+
+            let is_focused = Some(hwnd) == focused_window;
+
+            // In monocle mode, only the monocle window on the focused
+            // monitor renders. Other windows on the focused monitor are
+            // visually covered; windows on other monitors keep their
+            // normal borders.
+            if focused_monocle && mon_idx == focused_monitor && !is_focused {
+                if let Some(border) = self.borders.get(&hwnd) {
+                    border.hide();
+                }
+                continue;
+            }
+
+            // Skip unfocused borders entirely when disabled by config.
+            if !is_focused && !unfocused_enabled {
+                if let Some(border) = self.borders.get(&hwnd) {
+                    border.hide();
+                }
+                continue;
+            }
+
+            let color = if is_focused {
+                if focused_monocle && mon_idx == focused_monitor {
+                    monocle_color
+                } else {
+                    focused_color
+                }
+            } else {
+                unfocused_color
+            };
+
+            // Maximized focused windows skip border rendering (the
+            // border would be invisible against the work-area edges or
+            // overflow off-screen).
+            if is_focused && focused_is_maximized {
+                if let Some(border) = self.borders.get(&hwnd) {
+                    border.hide();
+                }
+                continue;
+            }
+
+            let border = match self.borders.get(&hwnd) {
+                Some(b) => b,
+                None => match Border::new() {
+                    Ok(b) => self.borders.entry(hwnd).or_insert(b),
+                    Err(e) => {
+                        mosaico_core::log_warn!("border.create failed for 0x{:X}: {}", hwnd, e);
+                        continue;
+                    }
+                },
+            };
+
+            border.show(&rect, color, width, radius, window.hwnd());
+        }
+    }
+
+    /// Returns `(hwnd, monitor_idx, rect)` for every window currently
+    /// laid out on its monitor's active workspace.
+    fn collect_visible_tiles(&self) -> Vec<(usize, usize, Rect)> {
+        let mut out = Vec::new();
+        for (mi, mon) in self.monitors.iter().enumerate() {
+            for &hwnd in mon.active_ws().handles() {
+                if let Ok(rect) = Window::from_raw(hwnd).rect() {
+                    out.push((hwnd, mi, rect));
+                }
+            }
+        }
+        out
+    }
+
+    /// Hides every border overlay without dropping them. Called on
+    /// daemon pause and on shutdown so borders stop rendering before
+    /// windows are restored to their original positions.
+    pub(super) fn hide_border(&self) {
+        for border in self.borders.values() {
+            border.hide();
+        }
+    }
+
+    /// Re-positions all border overlays to match the current window rects.
+    ///
+    /// Call after work areas change (e.g. bar adjustment at startup)
+    /// so borders reflect the final window positions.
+    pub fn refresh_border(&mut self) {
         self.update_border();
     }
 
@@ -118,4 +210,11 @@ impl TilingManager {
             self.focus_and_update_border(hwnd);
         }
     }
+}
+
+fn parse_color(hex: &str) -> Color {
+    if hex == BorderColors::NONE {
+        return FALLBACK_COLOR;
+    }
+    Color::from_hex(hex).unwrap_or(FALLBACK_COLOR)
 }

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -8,7 +8,7 @@ mod navigation;
 mod navigation_helpers;
 mod workspace;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use mosaico_core::action::MAX_WORKSPACES;
@@ -59,7 +59,14 @@ pub struct TilingManager {
     layout_gap: i32,
     layout_ratio: f64,
     rules: Vec<WindowRule>,
-    border: Option<Border>,
+    /// One overlay per visible tiled window keyed by hwnd.
+    ///
+    /// The focused window's border is drawn in the focused (or monocle)
+    /// color; the rest are drawn in the unfocused color when that
+    /// state is enabled (`BorderColors::unfocused_enabled`). Borders
+    /// are created lazily as windows are added to a visible workspace
+    /// and dropped when they leave.
+    borders: HashMap<usize, Border>,
     border_config: BorderConfig,
     focused_monitor: usize,
     focused_window: Option<usize>,
@@ -141,7 +148,6 @@ impl TilingManager {
             })
             .collect();
 
-        let border = Border::new().ok();
         let self_elevated = crate::process::is_current_process_elevated();
 
         let mut manager = Self {
@@ -149,7 +155,7 @@ impl TilingManager {
             layout_gap: layout_config.gap,
             layout_ratio: layout_config.ratio,
             rules,
-            border,
+            borders: HashMap::new(),
             border_config,
             focused_monitor: 0,
             focused_window: None,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,9 +27,12 @@ All settings have sensible defaults, so configuration files are optional.
 - `HidingBehaviour` (enum) -- `Cloak`, `Hide`, `Minimize`
 - `BorderConfig` -- `width: i32` (default 4), `corner_style: CornerStyle`,
   `colors: BorderColors`
-- `BorderColors` -- `focused: String` and `monocle: String`. Both default
-  to empty strings and resolve from the active theme (`"#89b4fa"` blue and
-  `"#a6e3a1"` green for Mocha)
+- `BorderColors` -- `focused: String`, `monocle: String`, and
+  `unfocused: String`. Empty strings resolve from the active theme
+  (Mocha defaults: `"#89b4fa"` blue, `"#a6e3a1"` green, `"#6c7086"`
+  muted gray). The literal `"none"` on `unfocused` disables borders
+  for unfocused windows entirely; `BorderColors::unfocused_enabled()`
+  reports the toggle state
 - `LogConfig` -- `enabled: bool` (default false), `level: String` (default
   `"info"`), `max_file_mb: u64` (default 10)
 - `WindowRule` -- `match_class: Option<String>`, `match_title: Option<String>`,
@@ -72,6 +75,8 @@ corner_style = "small" # "square", "small", or "round"
 [borders.colors]
 focused = "#00b4d8"    # Color of the focused window in tiled layouts
 monocle = "#2d6a4f"    # Color of the focused window in monocle mode
+unfocused = "#6c7086"  # Color drawn around unfocused tiled windows
+                       # (set to "none" to disable unfocused borders)
 
 [theme]
 flavor = "mocha"   # Catppuccin flavor: latte, frappe, macchiato, mocha

--- a/docs/focus-border.md
+++ b/docs/focus-border.md
@@ -1,8 +1,14 @@
-# Focus Border Overlay
+# Window Border Overlays
 
-Mosaico displays a colored rectangular border around the focused window to
-provide clear visual feedback. The border is a transparent overlay window that
-uses `UpdateLayeredWindow` with per-pixel alpha for flicker-free rendering.
+Mosaico draws a colored rectangular border around every visible tiled
+window. The focused window is highlighted with the focused (or monocle)
+color; other tiled windows on every monitor's active workspace are drawn
+in a muted unfocused color so tile boundaries stay readable, especially
+with small gaps. Each border is a transparent overlay window that uses
+`UpdateLayeredWindow` with per-pixel alpha for flicker-free rendering.
+
+Unfocused borders can be turned off entirely (see
+[Configuration](#configuration) below) when a minimal look is preferred.
 
 ## Architecture
 
@@ -62,20 +68,36 @@ a stale bitmap from the previous size would briefly appear at the new position.
 The `Color` struct represents an RGB color:
 
 - `Color::from_hex(s)` -- parses `"#RRGGBB"` or `"RRGGBB"` format strings
-- Default focused color: `#00b4d8` (cyan)
-- Default monocle color: `#2d6a4f` (dark green)
+- Default focused color: theme-resolved (Mocha: `#89b4fa` blue)
+- Default monocle color: theme-resolved (Mocha: `#a6e3a1` green)
+- Default unfocused color: theme-resolved (Mocha: `#6c7086` muted gray)
+
+The literal `"none"` on `unfocused` disables unfocused borders;
+`BorderColors::unfocused_enabled()` reports the toggle state.
 
 ## Integration
 
-The `TilingManager` creates one `Border` instance at startup and manages its
-lifecycle:
+The `TilingManager` keeps a `HashMap<usize, Border>` keyed by `hwnd`,
+with one entry per visible tiled window. The lifecycle is unified
+through a single entry point:
 
-- `update_border()` -- called on focus changes; shows the border around the
-  focused window with the appropriate color (normal or monocle)
-- `hide_border()` -- called when focus leaves all managed windows
+- `update_border()` -- called after every layout, focus, workspace, or
+  display event. It snapshots the active workspace on every monitor,
+  drops borders for windows that are no longer visible, creates
+  borders for new windows, and recolors each surviving border based on
+  whether it owns focus.
+- `hide_border()` -- hides every overlay without dropping them
+  (used on pause and shutdown).
 
-The border color changes between the configured `focused` color and `monocle`
-color depending on whether monocle mode is active on the focused monitor.
+Color selection per window:
+
+- The focused window uses the configured `focused` color, or the
+  `monocle` color if its monitor is in monocle mode.
+- Every other window on the active workspace of every monitor uses the
+  `unfocused` color, unless that color is set to the `"none"` sentinel
+  (in which case unfocused windows have no border).
+- Maximized focused windows skip rendering, and on the focused monitor
+  only the monocle window renders while monocle mode is active.
 
 ## Configuration
 
@@ -87,11 +109,14 @@ width = 4              # Border thickness in pixels (0-32)
 corner_style = "small" # "square", "small", or "round"
 
 [borders.colors]
-focused = "#00b4d8"    # Color for normal focused window
+focused = "#00b4d8"    # Color for the focused window in tiled layouts
 monocle = "#2d6a4f"    # Color when monocle mode is active
+unfocused = "#6c7086"  # Color drawn around unfocused tiled windows;
+                       # set to "none" to disable unfocused borders
 ```
 
-Setting `width = 0` effectively disables the border.
+Setting `width = 0` disables every border. To keep the focused border
+but hide unfocused ones, set `unfocused = "none"`.
 
 ### Rounded Corners
 
@@ -121,10 +146,15 @@ overlay is affected.
   would cause recursive tiling loops.
 - **DIB section rendering** gives full control over per-pixel alpha without
   depending on GDI drawing primitives, which have limited alpha support.
-- **Single border instance** is reused and repositioned rather than creating
-  a new window for each focus change, avoiding window creation overhead.
+- **One overlay per visible window**, keyed by `hwnd` in a `HashMap`.
+  Borders are created lazily when a window is first added to a visible
+  workspace and dropped (via `Drop`, which calls `DestroyWindow`) when
+  the window leaves it. This avoids scanning a Vec on every update at
+  the cost of one layered window per tile.
 
 ## Tests
 
-1 unit test for `Color::from_hex()` covering both `#RRGGBB` and `RRGGBB`
-formats.
+`Color::from_hex()` is covered by unit tests for both `#RRGGBB` and
+`RRGGBB` formats. Theme tests assert that `border_focused`,
+`border_monocle`, and `border_unfocused` are distinct per flavor and
+match their Catppuccin palette values.

--- a/website/src/guide/configuration.md
+++ b/website/src/guide/configuration.md
@@ -45,6 +45,8 @@ corner_style = "small" # "square", "small", or "round"
 [borders.colors]
 focused = "#00b4d8"    # Color of the focused window in tiled layouts
 monocle = "#2d6a4f"    # Color of the focused window in monocle mode
+unfocused = "#6c7086"  # Color drawn around unfocused tiled windows;
+                       # set to "none" to disable unfocused borders
 
 [theme]
 flavor = "mocha"   # Catppuccin flavor: latte, frappe, macchiato, mocha

--- a/website/src/guide/focus-border.md
+++ b/website/src/guide/focus-border.md
@@ -1,7 +1,11 @@
-# Focus Borders
+# Window Borders
 
-Mosaico draws a colored border overlay around the currently focused window,
-making it easy to identify which window has focus.
+Mosaico draws a colored border overlay around every visible tiled
+window. The focused window is highlighted with the focused (or monocle)
+color; every other tiled window on the active workspace gets a muted
+unfocused border so tile boundaries stay readable -- especially with
+small gaps. Unfocused borders can be disabled if you prefer a minimal
+look.
 
 ## Configuration
 
@@ -15,10 +19,11 @@ corner_style = "small" # "square", "small", or "round"
 [borders.colors]
 focused = "#00b4d8"    # Color for focused window in tiled layouts
 monocle = "#2d6a4f"    # Color for focused window in monocle mode
+unfocused = "#6c7086"  # Color drawn around unfocused tiled windows
 ```
 
 - **width** -- thickness of the border in pixels. Set to `0` to disable
-  the focus border entirely.
+  every border.
 - **corner_style** -- controls both the border overlay shape and the
   DWM corner preference for tiled windows (Windows 11 only; ignored
   on Windows 10).
@@ -29,17 +34,33 @@ monocle = "#2d6a4f"    # Color for focused window in monocle mode
   | `"small"` | Subtle rounding (8 px) | `ROUNDSMALL` (~4 px) |
   | `"round"` | Standard rounding (16 px) | `ROUND` (~8 px) |
 
-- **borders.colors.focused** -- the border color during normal tiling.
-  Accepts hex colors or named Catppuccin colors (see [Theming](theming.md)).
-- **borders.colors.monocle** -- the border color when monocle mode is active.
+- **borders.colors.focused** -- the border color for the focused window
+  during normal tiling. Accepts hex colors or named theme colors
+  (see [Theming](theming.md)).
+- **borders.colors.monocle** -- the border color when monocle mode is
+  active.
+- **borders.colors.unfocused** -- the border color drawn around every
+  unfocused tiled window. Set to `"none"` to disable unfocused borders
+  entirely (only the focused window will have a border in that case).
+  An empty string falls back to the active theme's muted-gray default.
 
 ## Behavior
 
-- The border automatically follows focus as you navigate between windows
-- It is a click-through overlay that does not interfere with your
-  interaction with the focused window
-- The border sits on top of all windows (topmost)
-- It is excluded from tiling (it is invisible to the tiling manager)
+- Every tiled window on every monitor's active workspace gets its own
+  border overlay.
+- Changing focus recolors the previously focused border to the
+  unfocused color and the new focused border to the focused color, in
+  one update.
+- Switching workspaces hides the outgoing windows' borders and shows
+  the incoming windows' borders.
+- In monocle mode only the focused window's border renders; all other
+  tiled borders on that monitor are hidden until monocle is toggled
+  off.
+- When the focused window is maximized, its border is hidden so it
+  does not overflow off-screen, and unfocused borders on the same
+  monitor are also hidden because they are visually covered.
+- Borders are click-through (`WS_EX_TRANSPARENT`) and never interfere
+  with mouse interaction.
 
 ## Using Named Colors
 
@@ -49,9 +70,28 @@ With a theme active, you can use named colors:
 [borders.colors]
 focused = "blue"
 monocle = "green"
+unfocused = "mauve"
 ```
+
+Empty values fall back to the theme's defaults: blue for focused,
+green for monocle, and a muted gray (Catppuccin Overlay0) for
+unfocused.
+
+## Disabling Unfocused Borders Only
+
+If you want the focus highlight without borders on every other window:
+
+```toml
+[borders.colors]
+unfocused = "none"
+```
+
+This keeps `focused` and `monocle` rendering as before and skips
+unfocused borders entirely. Use `width = 0` instead if you want every
+border off.
 
 ## Hot-Reload
 
 Border settings are hot-reloaded. Changes to `width`, `corner_style`,
-and the `[borders.colors]` entries take effect immediately.
+and any `[borders.colors]` entry take effect immediately, including
+flipping `unfocused = "none"` on or off.


### PR DESCRIPTION
## Summary

Adds a third border color slot, `unfocused`, under `[borders.colors]` and renders an overlay around every visible tiled window so tile boundaries stay readable, especially at small gap values. The focused window keeps its existing focused (or monocle) color; every other window on every monitor's active workspace now renders in the new unfocused color.

```toml
[borders.colors]
focused = "#00b4d8"    # focused window in tiled layouts
monocle = "#2d6a4f"    # focused window in monocle mode
unfocused = "#6c7086"  # every other tiled window
                       # set to "none" to disable unfocused borders
```

## Schema

- `BorderColors` gains `unfocused: String`, a `NONE` sentinel (`"none"`), and an `unfocused_enabled()` helper.
- Empty resolves to a theme-aware muted gray (Catppuccin Overlay0 per flavor: Mocha `#6c7086`, Macchiato `#6e738d`, Frappe `#737994`, Latte `#9ca0b0`).
- `unfocused = "none"` disables unfocused borders without touching the focused or monocle ones. `Config::validate` preserves the sentinel verbatim and otherwise resolves through the theme palette like the other color fields.

## Rendering

- `TilingManager.border: Option<Border>` is replaced by `borders: HashMap<usize, Border>` keyed by hwnd. `update_border` now walks every monitor's active workspace, drops borders for windows that have left it, creates borders for new ones, and recolors each surviving border based on focus and monocle state.
- Maximized focused windows and monocle-covered neighbors still hide their borders just like before.
- `ConfigReload::Config(Config)` is boxed to silence the `large_enum_variant` lint that fires now that `Config` is a bit larger.

## Discoverability for existing users

A second pass in `merge_missing_config_sections` adds the new key to the user's config so the option is documented inline. Two strategies, in order:

1. **Inline insertion**: if `[borders.colors]` is an active table without `unfocused`, insert `unfocused = ""` into it via `toml_edit`, with a leading comment explaining recognized values. Empty preserves current behavior; the user can edit to `"none"` or a color.
2. **Bottom hint fallback**: if `[borders.colors]` is absent or fully commented out, append a standalone comment block at the end of the file.

Both paths are idempotent. The substring `unfocused` (active key, inserted comment, prior bottom hint, or commented-out template line) suppresses further work.

After upgrade, an existing config that looks like:
```toml
[borders.colors]
# focused = "blue"
monocle = "red"
```
becomes:
```toml
[borders.colors]
# focused = "blue"
monocle = "red"

# Color drawn around unfocused tiled windows.
# "none" disables unfocused borders; "" (empty) uses the
# theme default (muted gray); a hex code or named theme color
# works too.
unfocused = ""
```

## Tests

- **Theme**: all four flavors return distinct unfocused colors; none collide with `focused` or `monocle`.
- **Resolve**: empty resolves to theme; `"none"` passes through and disables; `"#deadbe"` passes through; `"mauve"` resolves via the palette.
- **Hint**: inline insertion when `[borders.colors]` is active; bottom comment when section is missing; both idempotent; explicit value or commented template suppresses any change.
- 222 lib tests total, fmt clean, clippy clean (`-D warnings`).

## Docs

- `docs/configuration.md`, `docs/focus-border.md`, `website/src/guide/configuration.md`, and `website/src/guide/focus-border.md` updated to describe the new field, the `"none"` sentinel, and the per-window border lifecycle.
- `mosaico init` template grows a documented `unfocused` line under `[borders.colors]`.

## Behavior change

Existing users on upgrade will see a subtle gray border around unfocused tiled windows. Add `unfocused = "none"` under `[borders.colors]` to restore the previous look (focused border only). The auto-merge inserts the field as `unfocused = ""` so the change is immediately discoverable inline.

## Test plan

- [x] Upgrade an existing install with active `[borders.colors] focused = "blue", monocle = "red"`. Start the daemon. Confirm the file gains `unfocused = ""` with the documented comment block above it, and that an `Info: appended unfocused border hint ...` line is logged.
- [x] Re-run the daemon. Confirm no second insertion (no log line, no duplicate key).
- [x] Open three windows in a tiled layout. Confirm the focused one has the focused color border and the other two have a muted gray border.
- [x] Switch focus with `Alt+H/J/K/L`. Confirm the borders recolor without flicker.
- [x] Toggle monocle with `Alt+T`. Confirm only the focused window's border renders (monocle color); the other two are hidden until monocle is toggled off.
- [x] Switch workspace with `Alt+2`. Confirm borders for the outgoing windows disappear and borders for the incoming windows appear at their tiled positions.
- [x] Edit `unfocused = "none"` in `config.toml` and save. Confirm unfocused borders disappear within the watcher's poll interval; the focused border remains.
- [x] Edit `unfocused = "mauve"` and save. Confirm unfocused borders turn the theme's mauve.
- [x] On a fresh install (`mosaico init`), confirm the generated `config.toml` includes a commented `# unfocused = "none"` line in the `[borders.colors]` section.
- [x] On a config without any `[borders.colors]` at all, confirm the bottom-hint comment block is appended on first daemon start and not duplicated on subsequent starts.
