### PR TITLE
chore(ci): skip Azure docs deploy on PR events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "website/**"
   pull_request:
-    types: [opened, synchronize, reopened, closed]
     branches:
       - main
     paths:
@@ -25,12 +24,17 @@ jobs:
         with:
           mdbook-version: "latest"
 
+      # Build on every event so a broken markdown change fails CI
+      # before merge.
       - name: Build Documentation
         run: mdbook build
         working-directory: website
 
+      # Only deploy to Azure on a push to main. Skipping pull_request
+      # events here means no per-PR preview environment is created.
       - name: Deploy
         id: deploy
+        if: github.event_name == 'push'
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}


### PR DESCRIPTION
## Summary

Every PR was creating a per-PR preview environment in Azure Static Web Apps that never got cleaned up, eventually hitting the staging environment quota and failing the deploy on PR #11.

We don't actually use the preview environments (the docs are readable locally via `mdbook serve`), so this PR removes them entirely:

- The `Deploy` step now has `if: github.event_name == 'push'`, so Azure is only touched when something lands on `main`.
- `mdbook build` still runs on PRs, so a broken markdown change (dead link, malformed table) still fails CI before merge.
- The `closed` event type is dropped from the `pull_request` trigger -- with no environments to tear down on close, the workflow has nothing to do there.

## One-time manual cleanup

This PR stops new previews from being created, but the existing stale ones still occupy slots in your subscription. Once this lands, go to the Azure portal:

1. Static Web App `mosaico-docs` -> **Environments**
2. Delete every preview environment (everything except `Production`)

That frees the quota that's currently blocking other PR deploys, and from then on no new preview environments will be created.

## Test plan

- [x] Merge this PR. Confirm the docs site still deploys to production from `main`.
- [x] Open a follow-up PR that touches `website/`. Confirm `Build and Deploy` runs `mdbook build` and skips the `Deploy` step (visible as "Deploy ... skipped" in the run log).
- [x] Confirm no new preview environment appears in the Azure portal for that follow-up PR.
