### PR TITLE
chore(plans): mark phases 1, 29, 31 as Complete

### DIFF
--- a/.plans/phase-01.md
+++ b/.plans/phase-01.md
@@ -1,6 +1,6 @@
 # Phase 1: Project Initialization
 
-**Status:** In Progress
+**Status:** Complete
 
 **Goal:** Have a building Rust executable and a git repo ready to push.
 

--- a/.plans/phase-29.md
+++ b/.plans/phase-29.md
@@ -1,6 +1,6 @@
 # Phase 29: Toggle Pause (Stop/Resume Daemon)
 
-**Status:** Pending
+**Status:** Complete
 
 **Goal:** Add a single command that pauses the daemon (stops managing
 windows) and can be resumed later, effectively a toggle.

--- a/.plans/phase-31.md
+++ b/.plans/phase-31.md
@@ -1,6 +1,6 @@
 # Phase 31: Unfocused Window Borders
 
-**Status:** Pending
+**Status:** Complete
 
 **Goal:** Add subtle borders around non-focused tiled windows so users can
 visually distinguish window boundaries, especially with small gaps.

--- a/.plans/plan.md
+++ b/.plans/plan.md
@@ -45,9 +45,9 @@ Mosaico is structured as a Cargo workspace with multiple crates:
 | [26](phase-26.md) | Floating Window Toggle | Pending |
 | [27](phase-27.md) | Additional Layouts & Layout Cycling | Complete |
 | [28](phase-28.md) | API Hygiene & Safety Audit | Complete |
-| [29](phase-29.md) | Toggle Pause (Stop/Resume Daemon) | Pending |
+| [29](phase-29.md) | Toggle Pause (Stop/Resume Daemon) | Complete |
 | [30](phase-30.md) | Windows Installer & Winget Distribution | Pending |
-| [31](phase-31.md) | Unfocused Window Borders | Pending |
+| [31](phase-31.md) | Unfocused Window Borders | Complete |
 | [32](phase-32.md) | Rosé Pine & Tokyo Night Themes | Pending |
 
 ## Design Principles


### PR DESCRIPTION
Sync the **Status** field on individual phase docs with reality and the `plan.md` table:

- **Phase 1** (Project Initialization): `plan.md` already marks it Complete; `phase-01.md` was still showing `In Progress`.
- **Phase 29** (Toggle Pause): shipped in the pause/unpause feature with `Alt+Shift+P`, `mosaico pause`/`unpause` CLI, and the `PAUSED` bar widget.
- **Phase 31** (Unfocused Window Borders): shipped in #11 -- per-window border overlays with focused/unfocused/monocle color states under `[borders.colors]`.

No code changes.

## Test plan

- [ ] Open `.plans/plan.md` in the rendered repo view; phases 1, 29, and 31 all show **Complete**.
- [ ] The remaining Pending entries (19, 25, 26, 30, 32) are unchanged.
