### PR TITLE
feat(themes): add Rose Pine and Tokyo Night themes

### DIFF
--- a/.plans/phase-33.md
+++ b/.plans/phase-33.md
@@ -1,0 +1,209 @@
+# Phase 33: Theme Accent Override
+
+**Status:** Pending
+
+**Goal:** Let users pick a custom accent color from the active theme's
+palette without having to override every individual color slot in
+`[bar.colors]` and `[borders.colors]`.
+
+## Overview
+
+Phase 32 introduced three theme families (Catppuccin, Rosé Pine, Tokyo
+Night) each with multiple flavors. Each flavor pins one specific
+palette color to the "lead" role: Iris for Rosé Pine, Blue for
+Catppuccin and Tokyo Night. A user who likes a flavor's overall
+palette but wants a different accent currently has to override four
+slots manually:
+
+```toml
+[bar.colors]
+foreground = "gold"
+inactive_workspace = "gold"
+pill_border = "gold"
+
+[borders.colors]
+focused = "gold"
+```
+
+This phase adds a single config field that does the same thing in
+one line:
+
+```toml
+[theme]
+name = "rose-pine"
+flavor = "main"
+accent = "gold"     # NEW: replaces Iris in all four "lead" slots
+```
+
+`accent` resolves through the active palette like any other named
+color, so the same field works under any theme: `accent = "mauve"`
+under Catppuccin Mocha, `accent = "purple"` under Tokyo Night, etc.
+
+## Configuration
+
+`ThemeConfig` gains an optional third field:
+
+```rust
+pub struct ThemeConfig {
+    pub name: String,
+    pub flavor: String,
+    pub accent: String,   // empty = family default; resolves via palette
+}
+```
+
+`accent` is `#[serde(default)]` so missing fields stay backward
+compatible.
+
+## Slots Affected
+
+When `accent` resolves to a non-empty hex, it replaces the lead color
+in:
+
+1. `bar.foreground`
+2. `bar.inactive_workspace`
+3. `bar.pill_border`
+4. `border_focused`
+
+Slots intentionally left alone (theme identity should still read as
+the chosen flavor):
+
+- `bar.background` -- the theme's base background
+- `bar.accent` -- the secondary accent slot stays on the flavor's
+  default (e.g. Rose under Rosé Pine, Green under Catppuccin)
+- `bar.widget_background` -- theme-specific surface
+- `border_monocle` -- monocle has its own meaning; stays Green
+- `border_unfocused` -- theme-specific muted gray; stays Subtle/Comment
+
+Net effect: `accent = "gold"` under Rosé Pine Main produces a
+recognizably Rosé Pine bar (Base background, Rose secondary, Foam
+monocle, Subtle unfocused) with a Gold lead instead of Iris.
+
+## Override Precedence
+
+User overrides in `[bar.colors]` or `[borders.colors]` still win over
+the accent field because they are more specific:
+
+```toml
+[theme]
+name = "rose-pine"
+accent = "gold"
+
+[borders.colors]
+focused = "love"      # this wins; focused border is Love, not Gold
+```
+
+The order of resolution becomes:
+
+1. Explicit hex / named color in `[bar.colors]` / `[borders.colors]`
+2. `[theme] accent` if set (and the slot is one of the four affected)
+3. Flavor's default
+
+## Architecture
+
+### Schema
+
+```rust
+// ThemeConfig
+pub struct ThemeConfig {
+    pub name: String,
+    pub flavor: String,
+    pub accent: String,
+}
+```
+
+### Resolution
+
+`Config::validate()` adds an accent-resolution step that runs after
+`resolve_borders()` and before the bar config is finalized:
+
+```rust
+fn resolve_accent(&mut self) {
+    if self.theme.accent.is_empty() {
+        return;
+    }
+    let theme = self.theme.resolve();
+    let Some(hex) = theme.named_color(&self.theme.accent) else {
+        eprintln!(
+            "Warning: unknown accent {:?} for theme {:?}; ignored",
+            self.theme.accent, self.theme.name
+        );
+        return;
+    };
+    // Override the four "lead" slots only when the user did not set
+    // them explicitly (empty string means "use theme default").
+    if self.borders.colors.focused == theme.border_focused() {
+        self.borders.colors.focused = hex.to_string();
+    }
+    // ... same for the three bar slots, gated on "still equal to
+    // the theme default" so explicit overrides win.
+}
+```
+
+The "still equal to the theme default" check is how we keep explicit
+user overrides winning. It compares the post-`resolve_borders` value
+to the flavor's canonical default; if the user set their own value,
+the post-resolve string differs and the accent skips that slot.
+
+### Bar resolution
+
+`BarConfig::resolve_colors()` already takes a `Theme`. We extend it
+to optionally take the resolved accent hex and apply the same
+"only-if-still-default" logic for `foreground`, `inactive_workspace`,
+and `pill_border`.
+
+## Modified Files
+
+```
+crates/mosaico-core/src/config/
+  theme.rs            # Add accent field to ThemeConfig
+  mod.rs              # Add resolve_accent() in Config::validate
+  bar.rs              # Thread accent through resolve_colors
+  template_config.rs  # Document accent in the [theme] block
+crates/mosaico-windows/src/
+  daemon_loop_handlers.rs  # Pass accent through on hot-reload
+```
+
+## Edge Cases
+
+1. **Unknown accent name**: log a warning and ignore (fall back to
+   flavor default).
+2. **Empty accent**: no-op, current behavior preserved.
+3. **Hex accent**: `accent = "#abc123"` should pass through directly
+   without going through the palette (matches how the existing
+   per-slot color fields work).
+4. **Accent collides with secondary slot**: if `accent = "rose"`
+   under Rosé Pine, both `bar.foreground` and `bar.accent` end up
+   as Rose. Acceptable; the user asked for it.
+5. **Hot-reload**: editing `accent` should re-resolve colors live,
+   same as editing `flavor`.
+
+## Tasks
+
+- [ ] Add `accent: String` to `ThemeConfig` (default empty)
+- [ ] Add `Config::resolve_accent()` running after
+      `resolve_borders()`; apply the "only-if-still-default" rule
+- [ ] Thread the resolved accent into `BarConfig::resolve_colors()`
+- [ ] Document `accent` in the `mosaico init` template `[theme]` block
+- [ ] Update `docs/configuration.md` and `docs/theming.md`
+- [ ] Update `website/src/guide/configuration.md` and
+      `website/src/guide/theming.md`
+- [ ] Add unit tests:
+  - accent overrides the four slots when set
+  - explicit `[borders.colors] focused = "..."` wins over accent
+  - unknown accent name is ignored with a warning
+  - hex accent (`accent = "#abc123"`) passes through
+  - hot-reload picks up new accent without restart
+- [ ] Run `cargo fmt --all`
+- [ ] Run `cargo clippy --all-targets -- -D warnings`
+- [ ] Run `cargo test --lib`
+- [ ] Manual test: set `accent = "gold"` under Rosé Pine, confirm
+      bar foreground + focused border turn gold while Rose remains
+      the secondary accent
+- [ ] Manual test: set `accent = "mauve"` under Catppuccin Mocha,
+      confirm bar lead turns mauve
+- [ ] Manual test: set `accent = "purple"` under Tokyo Night, confirm
+      similar
+- [ ] Manual test: set both `accent = "gold"` and
+      `[borders.colors] focused = "love"`, confirm the explicit
+      override wins for the focused border but the bar still reads gold
+- [ ] Update `.plans/plan.md`

--- a/.plans/plan.md
+++ b/.plans/plan.md
@@ -49,6 +49,7 @@ Mosaico is structured as a Cargo workspace with multiple crates:
 | [30](phase-30.md) | Windows Installer & Winget Distribution | Pending |
 | [31](phase-31.md) | Unfocused Window Borders | Pending |
 | [32](phase-32.md) | Rosé Pine & Tokyo Night Themes | Pending |
+| [33](phase-33.md) | Theme Accent Override | Pending |
 
 ## Design Principles
 

--- a/crates/mosaico-core/src/config/bar.rs
+++ b/crates/mosaico-core/src/config/bar.rs
@@ -482,6 +482,7 @@ impl BarConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::theme::CatppuccinFlavor;
 
     #[test]
     fn default_bar_config_has_expected_values() {
@@ -552,7 +553,7 @@ mod tests {
     #[test]
     fn resolve_colors_fills_from_theme() {
         let mut config = BarConfig::default();
-        config.resolve_colors(Theme::Mocha);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Mocha));
 
         assert_eq!(config.colors.background, "#1e1e2e");
         assert_eq!(config.colors.widget_background, "#313244");
@@ -562,7 +563,7 @@ mod tests {
     #[test]
     fn bar_config_round_trips_through_toml() {
         let mut config = BarConfig::default();
-        config.resolve_colors(Theme::Mocha);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Mocha));
         let toml_str = toml::to_string(&config).unwrap();
         let parsed: BarConfig = toml::from_str(&toml_str).unwrap();
 
@@ -659,7 +660,7 @@ mod tests {
     #[test]
     fn resolve_colors_latte_fills_light_colors() {
         let mut config = BarConfig::default();
-        config.resolve_colors(Theme::Latte);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Latte));
         assert_eq!(config.colors.background, "#eff1f5");
         assert_eq!(config.colors.foreground, "#1e66f5");
     }
@@ -668,7 +669,7 @@ mod tests {
     fn explicit_color_overrides_theme() {
         let toml_str = "[colors]\nbackground = \"#000000\"\n";
         let mut config: BarConfig = toml::from_str(toml_str).unwrap();
-        config.resolve_colors(Theme::Latte);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Latte));
 
         // Explicit override kept
         assert_eq!(config.colors.background, "#000000");
@@ -680,7 +681,7 @@ mod tests {
     fn named_color_in_bar_resolves_to_hex() {
         let toml_str = "[colors]\naccent = \"mauve\"\n";
         let mut config: BarConfig = toml::from_str(toml_str).unwrap();
-        config.resolve_colors(Theme::Mocha);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Mocha));
 
         assert_eq!(config.colors.accent, "#cba6f7");
         // Unset fields still resolved from theme
@@ -690,7 +691,7 @@ mod tests {
     #[test]
     fn widget_color_resolves_named_to_hex() {
         let mut config = BarConfig::default();
-        config.resolve_colors(Theme::Mocha);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Mocha));
         // Update widget defaults to "green", resolved to Mocha green hex.
         let update = config
             .right
@@ -703,7 +704,7 @@ mod tests {
     #[test]
     fn widget_color_empty_means_no_override() {
         let mut config = BarConfig::default();
-        config.resolve_colors(Theme::Mocha);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Mocha));
         // Clock has no custom color — stays empty.
         let clock = config
             .right
@@ -717,7 +718,7 @@ mod tests {
     fn widget_color_from_toml() {
         let toml_str = "[[left]]\ntype = \"layout\"\ncolor = \"red\"\n";
         let mut config: BarConfig = toml::from_str(toml_str).unwrap();
-        config.resolve_colors(Theme::Mocha);
+        config.resolve_colors(Theme::Catppuccin(CatppuccinFlavor::Mocha));
         assert_eq!(config.left[0].color(), "#f38ba8");
     }
 }

--- a/crates/mosaico-core/src/config/mod.rs
+++ b/crates/mosaico-core/src/config/mod.rs
@@ -26,7 +26,7 @@ pub use loader::{
     try_load_keybindings, try_load_rules, try_load_user_rules, user_rules_path,
 };
 pub use rules::{WindowRule, default_rules, should_manage, validate_rules};
-pub use theme::{Theme, ThemeConfig};
+pub use theme::{CatppuccinFlavor, RosePineFlavor, Theme, ThemeConfig, TokyoNightFlavor};
 pub use types::*;
 
 /// Top-level configuration for Mosaico.

--- a/crates/mosaico-core/src/config/palette/catppuccin.rs
+++ b/crates/mosaico-core/src/config/palette/catppuccin.rs
@@ -1,37 +1,27 @@
-//! Catppuccin color palettes for each theme flavor.
+//! Catppuccin color palettes (Mocha, Macchiato, Frappé, Latte).
 //!
-//! Provides the full named-color palette and the [`BarColors`]
-//! mapping for each theme.
+//! See <https://catppuccin.com/palette/> for the canonical hex values.
 
-use super::bar::BarColors;
-use super::theme::Theme;
+use crate::config::bar::BarColors;
+use crate::config::theme::CatppuccinFlavor;
 
-/// Resolves a Catppuccin color name (e.g. "blue", "green") to its
-/// hex value for the given theme. Returns `None` for unknown names.
-pub fn named_color(theme: Theme, name: &str) -> Option<&'static str> {
-    let table = match theme {
-        Theme::Mocha => MOCHA,
-        Theme::Macchiato => MACCHIATO,
-        Theme::Frappe => FRAPPE,
-        Theme::Latte => LATTE,
-    };
-    table
-        .iter()
-        .find(|(n, _)| n.eq_ignore_ascii_case(name))
-        .map(|(_, hex)| *hex)
-}
-
-/// Returns the bar color palette for the given theme.
-pub fn bar_colors(theme: Theme) -> BarColors {
-    match theme {
-        Theme::Mocha => mocha_bar(),
-        Theme::Macchiato => macchiato_bar(),
-        Theme::Frappe => frappe_bar(),
-        Theme::Latte => latte_bar(),
+pub(super) fn table(flavor: CatppuccinFlavor) -> &'static [(&'static str, &'static str)] {
+    match flavor {
+        CatppuccinFlavor::Mocha => MOCHA,
+        CatppuccinFlavor::Macchiato => MACCHIATO,
+        CatppuccinFlavor::Frappe => FRAPPE,
+        CatppuccinFlavor::Latte => LATTE,
     }
 }
 
-// -- Named color tables (14 accent colors per flavor) ----------------
+pub(super) fn bar_colors(flavor: CatppuccinFlavor) -> BarColors {
+    match flavor {
+        CatppuccinFlavor::Mocha => mocha_bar(),
+        CatppuccinFlavor::Macchiato => macchiato_bar(),
+        CatppuccinFlavor::Frappe => frappe_bar(),
+        CatppuccinFlavor::Latte => latte_bar(),
+    }
+}
 
 const MOCHA: &[(&str, &str)] = &[
     ("rosewater", "#f5e0dc"),
@@ -101,8 +91,6 @@ const LATTE: &[(&str, &str)] = &[
     ("lavender", "#7287fd"),
 ];
 
-// -- Bar color mappings per theme ------------------------------------
-
 fn mocha_bar() -> BarColors {
     BarColors {
         background: "#1e1e2e".into(),
@@ -164,28 +152,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn named_color_resolves_blue() {
-        assert_eq!(named_color(Theme::Mocha, "blue"), Some("#89b4fa"));
-        assert_eq!(named_color(Theme::Latte, "blue"), Some("#1e66f5"));
-    }
-
-    #[test]
-    fn named_color_is_case_insensitive() {
-        assert_eq!(named_color(Theme::Mocha, "Blue"), Some("#89b4fa"));
-        assert_eq!(named_color(Theme::Mocha, "GREEN"), Some("#a6e3a1"));
-    }
-
-    #[test]
-    fn named_color_returns_none_for_unknown() {
-        assert_eq!(named_color(Theme::Mocha, "chartreuse"), None);
-        assert_eq!(named_color(Theme::Mocha, "#89b4fa"), None);
-    }
-
-    #[test]
-    fn each_theme_has_14_named_colors() {
+    fn each_flavor_has_14_named_colors() {
         assert_eq!(MOCHA.len(), 14);
         assert_eq!(MACCHIATO.len(), 14);
         assert_eq!(FRAPPE.len(), 14);
         assert_eq!(LATTE.len(), 14);
+    }
+
+    #[test]
+    fn mocha_blue_matches_catppuccin_palette() {
+        let blue = MOCHA.iter().find(|(n, _)| *n == "blue").map(|(_, h)| *h);
+        assert_eq!(blue, Some("#89b4fa"));
     }
 }

--- a/crates/mosaico-core/src/config/palette/mod.rs
+++ b/crates/mosaico-core/src/config/palette/mod.rs
@@ -1,0 +1,112 @@
+//! Color palettes for each supported theme family.
+//!
+//! Public dispatchers route lookups to the right family module based
+//! on the resolved [`Theme`] variant.
+
+mod catppuccin;
+mod rose_pine;
+mod tokyo_night;
+
+use super::bar::BarColors;
+use super::theme::Theme;
+
+/// Resolves a named theme color (e.g. `"blue"`, `"pine"`) to its hex
+/// value for the given theme. Returns `None` for unknown names.
+///
+/// Common color names like `"red"`, `"blue"`, `"green"`, `"yellow"`
+/// resolve in every theme family so `focused = "blue"` works
+/// regardless of which theme the user picks; family-specific names
+/// (`pine`, `iris`, `magenta`, ...) only resolve under their own
+/// family.
+pub fn named_color(theme: Theme, name: &str) -> Option<&'static str> {
+    let table: &[(&str, &str)] = match theme {
+        Theme::Catppuccin(f) => catppuccin::table(f),
+        Theme::RosePine(f) => rose_pine::table(f),
+        Theme::TokyoNight(f) => tokyo_night::table(f),
+    };
+    table
+        .iter()
+        .find(|(n, _)| n.eq_ignore_ascii_case(name))
+        .map(|(_, hex)| *hex)
+}
+
+/// Returns the bar color palette for the given theme.
+pub fn bar_colors(theme: Theme) -> BarColors {
+    match theme {
+        Theme::Catppuccin(f) => catppuccin::bar_colors(f),
+        Theme::RosePine(f) => rose_pine::bar_colors(f),
+        Theme::TokyoNight(f) => tokyo_night::bar_colors(f),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::theme::{CatppuccinFlavor, RosePineFlavor, TokyoNightFlavor};
+
+    #[test]
+    fn named_color_resolves_blue_for_each_family() {
+        // Common name "blue" works under every theme family so
+        // portable configs (focused = "blue") look right regardless
+        // of the theme the user picks.
+        assert!(named_color(Theme::Catppuccin(CatppuccinFlavor::Mocha), "blue").is_some());
+        assert!(named_color(Theme::RosePine(RosePineFlavor::Main), "blue").is_some());
+        assert!(named_color(Theme::TokyoNight(TokyoNightFlavor::Night), "blue").is_some());
+    }
+
+    #[test]
+    fn named_color_is_case_insensitive() {
+        let mocha = Theme::Catppuccin(CatppuccinFlavor::Mocha);
+        assert_eq!(named_color(mocha, "Blue"), Some("#89b4fa"));
+        assert_eq!(named_color(mocha, "GREEN"), Some("#a6e3a1"));
+
+        let pine = Theme::RosePine(RosePineFlavor::Main);
+        assert_eq!(named_color(pine, "PINE"), named_color(pine, "pine"));
+    }
+
+    #[test]
+    fn named_color_returns_none_for_unknown() {
+        let mocha = Theme::Catppuccin(CatppuccinFlavor::Mocha);
+        assert_eq!(named_color(mocha, "chartreuse"), None);
+        // Hex codes are not resolved as named colors.
+        assert_eq!(named_color(mocha, "#89b4fa"), None);
+    }
+
+    #[test]
+    fn family_specific_names_do_not_leak_across_families() {
+        // `pine` is a Rosé Pine name, not a Catppuccin one.
+        assert!(named_color(Theme::RosePine(RosePineFlavor::Main), "pine").is_some());
+        assert!(named_color(Theme::Catppuccin(CatppuccinFlavor::Mocha), "pine").is_none());
+
+        // `mauve` resolves under both Catppuccin (native) and Tokyo
+        // Night (alias for purple).
+        assert!(named_color(Theme::Catppuccin(CatppuccinFlavor::Mocha), "mauve").is_some());
+        assert!(named_color(Theme::TokyoNight(TokyoNightFlavor::Night), "mauve").is_some());
+    }
+
+    #[test]
+    fn common_aliases_resolve_in_every_theme() {
+        // The four most-used names work under every supported theme.
+        // Distinct themes return distinct shades.
+        let themes = [
+            Theme::Catppuccin(CatppuccinFlavor::Mocha),
+            Theme::Catppuccin(CatppuccinFlavor::Macchiato),
+            Theme::Catppuccin(CatppuccinFlavor::Frappe),
+            Theme::Catppuccin(CatppuccinFlavor::Latte),
+            Theme::RosePine(RosePineFlavor::Main),
+            Theme::RosePine(RosePineFlavor::Moon),
+            Theme::RosePine(RosePineFlavor::Dawn),
+            Theme::TokyoNight(TokyoNightFlavor::Night),
+            Theme::TokyoNight(TokyoNightFlavor::Storm),
+            Theme::TokyoNight(TokyoNightFlavor::Day),
+        ];
+        for name in ["red", "green", "blue", "yellow"] {
+            for theme in themes {
+                assert!(
+                    named_color(theme, name).is_some(),
+                    "{name} should resolve in {theme:?}"
+                );
+            }
+        }
+    }
+}

--- a/crates/mosaico-core/src/config/palette/rose_pine.rs
+++ b/crates/mosaico-core/src/config/palette/rose_pine.rs
@@ -1,0 +1,167 @@
+//! Rosé Pine color palettes (Main, Moon, Dawn).
+//!
+//! See <https://rosepinetheme.com/palette/> for the canonical hex
+//! values. Each flavor exposes Rosé Pine's six accent colors (love,
+//! gold, rose, pine, foam, iris) plus common aliases (red, yellow,
+//! green, blue) so portable configs like `focused = "blue"` resolve
+//! to a Rosé Pine shade rather than nothing.
+
+use crate::config::bar::BarColors;
+use crate::config::theme::RosePineFlavor;
+
+pub(super) fn table(flavor: RosePineFlavor) -> &'static [(&'static str, &'static str)] {
+    match flavor {
+        RosePineFlavor::Main => MAIN,
+        RosePineFlavor::Moon => MOON,
+        RosePineFlavor::Dawn => DAWN,
+    }
+}
+
+pub(super) fn bar_colors(flavor: RosePineFlavor) -> BarColors {
+    match flavor {
+        RosePineFlavor::Main => main_bar(),
+        RosePineFlavor::Moon => moon_bar(),
+        RosePineFlavor::Dawn => dawn_bar(),
+    }
+}
+
+const MAIN: &[(&str, &str)] = &[
+    // Rosé Pine native accents
+    ("love", "#eb6f92"),
+    ("gold", "#f6c177"),
+    ("rose", "#ebbcba"),
+    ("pine", "#31748f"),
+    ("foam", "#9ccfd8"),
+    ("iris", "#c4a7e7"),
+    // Common color aliases for portable configs
+    ("red", "#eb6f92"),     // alias for love
+    ("yellow", "#f6c177"),  // alias for gold
+    ("green", "#9ccfd8"),   // alias for foam
+    ("blue", "#31748f"),    // alias for pine
+    ("teal", "#9ccfd8"),    // alias for foam
+    ("mauve", "#c4a7e7"),   // alias for iris
+    ("purple", "#c4a7e7"),  // alias for iris
+    ("magenta", "#c4a7e7"), // alias for iris
+];
+
+const MOON: &[(&str, &str)] = &[
+    ("love", "#eb6f92"),
+    ("gold", "#f6c177"),
+    ("rose", "#ea9a97"),
+    ("pine", "#3e8fb0"),
+    ("foam", "#9ccfd8"),
+    ("iris", "#c4a7e7"),
+    ("red", "#eb6f92"),
+    ("yellow", "#f6c177"),
+    ("green", "#9ccfd8"),
+    ("blue", "#3e8fb0"),
+    ("teal", "#9ccfd8"),
+    ("mauve", "#c4a7e7"),
+    ("purple", "#c4a7e7"),
+    ("magenta", "#c4a7e7"),
+];
+
+const DAWN: &[(&str, &str)] = &[
+    ("love", "#b4637a"),
+    ("gold", "#ea9d34"),
+    ("rose", "#d7827e"),
+    ("pine", "#286983"),
+    ("foam", "#56949f"),
+    ("iris", "#907aa9"),
+    ("red", "#b4637a"),
+    ("yellow", "#ea9d34"),
+    ("green", "#56949f"),
+    ("blue", "#286983"),
+    ("teal", "#56949f"),
+    ("mauve", "#907aa9"),
+    ("purple", "#907aa9"),
+    ("magenta", "#907aa9"),
+];
+
+// Bar identity uses Iris (purple) for foreground/pill borders and
+// Rose (the namesake) for the secondary accent. Pine is reserved for
+// the focus border (canonical "active" color in upstream Rose Pine
+// implementations) so both Iris/Rose and Pine end up visible.
+
+fn main_bar() -> BarColors {
+    BarColors {
+        background: "#191724".into(),            // Base
+        foreground: "#c4a7e7".into(),            // Iris
+        active_workspace: "#403d52".into(),      // Highlight Med
+        active_workspace_text: "#e0def4".into(), // Text
+        inactive_workspace: "#c4a7e7".into(),    // Iris
+        separator: "#26233a".into(),             // Overlay
+        accent: "#ebbcba".into(),                // Rose
+        widget_background: "#1f1d2e".into(),     // Surface
+        pill_border: "#c4a7e7".into(),           // Iris
+    }
+}
+
+fn moon_bar() -> BarColors {
+    BarColors {
+        background: "#232136".into(),            // Base
+        foreground: "#c4a7e7".into(),            // Iris
+        active_workspace: "#44415a".into(),      // Highlight Med
+        active_workspace_text: "#e0def4".into(), // Text
+        inactive_workspace: "#c4a7e7".into(),    // Iris
+        separator: "#393552".into(),             // Overlay
+        accent: "#ea9a97".into(),                // Rose (Moon variant)
+        widget_background: "#2a273f".into(),     // Surface
+        pill_border: "#c4a7e7".into(),           // Iris
+    }
+}
+
+fn dawn_bar() -> BarColors {
+    BarColors {
+        background: "#faf4ed".into(),            // Base
+        foreground: "#907aa9".into(),            // Iris (Dawn variant)
+        active_workspace: "#dfdad9".into(),      // Highlight Med
+        active_workspace_text: "#575279".into(), // Text
+        inactive_workspace: "#907aa9".into(),    // Iris
+        separator: "#cecacd".into(),             // Highlight High
+        accent: "#d7827e".into(),                // Rose (Dawn variant)
+        widget_background: "#fffaf3".into(),     // Surface
+        pill_border: "#907aa9".into(),           // Iris
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_flavor_has_pine_and_blue_alias() {
+        for (table, name) in [(MAIN, "main"), (MOON, "moon"), (DAWN, "dawn")] {
+            let pine = table.iter().find(|(n, _)| *n == "pine").map(|(_, h)| *h);
+            let blue = table.iter().find(|(n, _)| *n == "blue").map(|(_, h)| *h);
+            assert!(pine.is_some(), "{name}: missing pine");
+            assert_eq!(pine, blue, "{name}: blue should alias pine");
+        }
+    }
+
+    #[test]
+    fn dawn_is_lighter_than_main() {
+        // Dawn's base is the lightest of the three (off-white).
+        assert_eq!(dawn_bar().background, "#faf4ed");
+        // Main's base is the darkest.
+        assert_eq!(main_bar().background, "#191724");
+    }
+
+    #[test]
+    fn bar_lead_color_is_rose_family() {
+        // The bar foreground (the most visible accent) uses Iris on
+        // dark flavors and Iris-Dawn on the light flavor so the
+        // Rose Pine identity reads as purple-rose, not teal.
+        assert_eq!(main_bar().foreground, "#c4a7e7");
+        assert_eq!(moon_bar().foreground, "#c4a7e7");
+        assert_eq!(dawn_bar().foreground, "#907aa9");
+    }
+
+    #[test]
+    fn bar_accent_uses_rose() {
+        // The secondary accent is the namesake Rose hex per flavor.
+        assert_eq!(main_bar().accent, "#ebbcba");
+        assert_eq!(moon_bar().accent, "#ea9a97");
+        assert_eq!(dawn_bar().accent, "#d7827e");
+    }
+}

--- a/crates/mosaico-core/src/config/palette/tokyo_night.rs
+++ b/crates/mosaico-core/src/config/palette/tokyo_night.rs
@@ -1,0 +1,163 @@
+//! Tokyo Night color palettes (Night, Storm, Day).
+//!
+//! Hex values come from the upstream Tokyo Night theme
+//! (<https://github.com/folke/tokyonight.nvim>). Night and Storm
+//! share their accent palette and only differ in the base background
+//! and a few surface shades.
+
+use crate::config::bar::BarColors;
+use crate::config::theme::TokyoNightFlavor;
+
+pub(super) fn table(flavor: TokyoNightFlavor) -> &'static [(&'static str, &'static str)] {
+    match flavor {
+        TokyoNightFlavor::Night => NIGHT,
+        TokyoNightFlavor::Storm => STORM,
+        TokyoNightFlavor::Day => DAY,
+    }
+}
+
+pub(super) fn bar_colors(flavor: TokyoNightFlavor) -> BarColors {
+    match flavor {
+        TokyoNightFlavor::Night => night_bar(),
+        TokyoNightFlavor::Storm => storm_bar(),
+        TokyoNightFlavor::Day => day_bar(),
+    }
+}
+
+const NIGHT: &[(&str, &str)] = &[
+    ("red", "#f7768e"),
+    ("orange", "#ff9e64"),
+    ("yellow", "#e0af68"),
+    ("green", "#9ece6a"),
+    ("cyan", "#7dcfff"),
+    ("teal", "#1abc9c"),
+    ("blue", "#7aa2f7"),
+    ("purple", "#9d7cd8"),
+    ("magenta", "#bb9af7"),
+    // Common aliases
+    ("mauve", "#bb9af7"), // alias for magenta
+];
+
+const STORM: &[(&str, &str)] = &[
+    ("red", "#f7768e"),
+    ("orange", "#ff9e64"),
+    ("yellow", "#e0af68"),
+    ("green", "#9ece6a"),
+    ("cyan", "#7dcfff"),
+    ("teal", "#1abc9c"),
+    ("blue", "#7aa2f7"),
+    ("purple", "#9d7cd8"),
+    ("magenta", "#bb9af7"),
+    ("mauve", "#bb9af7"),
+];
+
+const DAY: &[(&str, &str)] = &[
+    ("red", "#f52a65"),
+    ("orange", "#b15c00"),
+    ("yellow", "#8c6c3e"),
+    ("green", "#587539"),
+    ("cyan", "#007197"),
+    ("teal", "#118c74"),
+    ("blue", "#2e7de9"),
+    ("purple", "#7847bd"),
+    ("magenta", "#9854f1"),
+    ("mauve", "#9854f1"),
+];
+
+fn night_bar() -> BarColors {
+    BarColors {
+        background: "#1a1b26".into(),
+        foreground: "#7aa2f7".into(), // blue
+        active_workspace: "#3b4261".into(),
+        active_workspace_text: "#c0caf5".into(),
+        inactive_workspace: "#7aa2f7".into(),
+        separator: "#414868".into(),
+        accent: "#9ece6a".into(), // green
+        widget_background: "#16161e".into(),
+        pill_border: "#7aa2f7".into(),
+    }
+}
+
+fn storm_bar() -> BarColors {
+    BarColors {
+        background: "#24283b".into(),
+        foreground: "#7aa2f7".into(),
+        active_workspace: "#3b4261".into(),
+        active_workspace_text: "#c0caf5".into(),
+        inactive_workspace: "#7aa2f7".into(),
+        separator: "#414868".into(),
+        accent: "#9ece6a".into(),
+        widget_background: "#1f2335".into(),
+        pill_border: "#7aa2f7".into(),
+    }
+}
+
+fn day_bar() -> BarColors {
+    BarColors {
+        background: "#e1e2e7".into(),
+        foreground: "#2e7de9".into(), // upstream Day blue
+        active_workspace: "#a8aecb".into(),
+        active_workspace_text: "#3760bf".into(),
+        inactive_workspace: "#2e7de9".into(),
+        separator: "#a8aecb".into(),
+        accent: "#587539".into(), // upstream Day green
+        widget_background: "#d0d5e3".into(),
+        pill_border: "#2e7de9".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn night_and_storm_share_accent_palette() {
+        let night_blue = NIGHT.iter().find(|(n, _)| *n == "blue").map(|(_, h)| *h);
+        let storm_blue = STORM.iter().find(|(n, _)| *n == "blue").map(|(_, h)| *h);
+        assert_eq!(night_blue, storm_blue);
+    }
+
+    #[test]
+    fn day_is_a_distinct_light_palette() {
+        let day_blue = DAY.iter().find(|(n, _)| *n == "blue").map(|(_, h)| *h);
+        let night_blue = NIGHT.iter().find(|(n, _)| *n == "blue").map(|(_, h)| *h);
+        assert_ne!(day_blue, night_blue);
+        assert_eq!(day_bar().background, "#e1e2e7");
+    }
+
+    #[test]
+    fn purple_and_magenta_are_distinct() {
+        // Upstream tokyonight.nvim has purple (#9d7cd8) and magenta
+        // (#bb9af7) as separate shades.
+        for table in [NIGHT, STORM] {
+            let purple = table.iter().find(|(n, _)| *n == "purple").map(|(_, h)| *h);
+            let magenta = table.iter().find(|(n, _)| *n == "magenta").map(|(_, h)| *h);
+            assert_eq!(purple, Some("#9d7cd8"));
+            assert_eq!(magenta, Some("#bb9af7"));
+        }
+        let day_purple = DAY.iter().find(|(n, _)| *n == "purple").map(|(_, h)| *h);
+        let day_magenta = DAY.iter().find(|(n, _)| *n == "magenta").map(|(_, h)| *h);
+        assert_eq!(day_purple, Some("#7847bd"));
+        assert_eq!(day_magenta, Some("#9854f1"));
+    }
+
+    #[test]
+    fn mauve_aliases_magenta() {
+        // `mauve` is a Catppuccin name; we expose it as an alias for
+        // magenta so portable configs (focused = "mauve") resolve
+        // under Tokyo Night too.
+        for table in [NIGHT, STORM, DAY] {
+            let magenta = table.iter().find(|(n, _)| *n == "magenta").map(|(_, h)| *h);
+            let mauve = table.iter().find(|(n, _)| *n == "mauve").map(|(_, h)| *h);
+            assert_eq!(magenta, mauve);
+        }
+    }
+
+    #[test]
+    fn day_red_matches_upstream() {
+        // Sanity-check a single Day value against tokyonight.nvim so
+        // a future copy-paste regression is caught.
+        let red = DAY.iter().find(|(n, _)| *n == "red").map(|(_, h)| *h);
+        assert_eq!(red, Some("#f52a65"));
+    }
+}

--- a/crates/mosaico-core/src/config/template_config.rs
+++ b/crates/mosaico-core/src/config/template_config.rs
@@ -7,7 +7,10 @@ pub fn generate_config() -> String {
 # Location: ~/.config/mosaico/config.toml
 
 # Color theme. Controls border colors and status bar colors.
-# Available: name = "catppuccin", flavor = mocha | macchiato | frappe | latte
+# Available themes:
+#   name = "catppuccin"   flavor = mocha | macchiato | frappe | latte
+#   name = "rose-pine"    flavor = main | moon | dawn
+#   name = "tokyo-night"  flavor = night | storm | day
 [theme]
 name = "catppuccin"
 flavor = "mocha"

--- a/crates/mosaico-core/src/config/tests.rs
+++ b/crates/mosaico-core/src/config/tests.rs
@@ -6,7 +6,10 @@ fn default_config_has_expected_values() {
     let mut config = Config::default();
     config.validate();
 
-    assert_eq!(config.theme.resolve(), Theme::Mocha);
+    assert_eq!(
+        config.theme.resolve(),
+        Theme::Catppuccin(CatppuccinFlavor::Mocha)
+    );
     assert_eq!(config.layout.gap, 8);
     assert_eq!(config.borders.width, 4);
 }

--- a/crates/mosaico-core/src/config/theme.rs
+++ b/crates/mosaico-core/src/config/theme.rs
@@ -20,14 +20,15 @@ use super::palette;
 /// flavor = "mocha"
 /// ```
 ///
-/// The two-field design allows future themes (e.g. `name = "tokyo"`,
-/// `flavor = "night"`) without changing the config schema.
+/// The two-field design lets the same config syntax address every
+/// theme family (Catppuccin, Rosé Pine, Tokyo Night, ...) without
+/// changing the schema.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ThemeConfig {
-    /// Theme family name (e.g. "catppuccin").
+    /// Theme family name (e.g. "catppuccin", "rose-pine", "tokyo-night").
     pub name: String,
-    /// Flavor or variant within the theme (e.g. "mocha", "latte").
+    /// Flavor or variant within the theme (e.g. "mocha", "moon", "night").
     pub flavor: String,
 }
 
@@ -46,33 +47,106 @@ impl ThemeConfig {
     /// Unknown name/flavor combinations fall back to Catppuccin Mocha.
     pub fn resolve(&self) -> Theme {
         match self.name.to_ascii_lowercase().as_str() {
-            "catppuccin" => match self.flavor.to_ascii_lowercase().as_str() {
-                "macchiato" => Theme::Macchiato,
-                "frappe" | "frappé" => Theme::Frappe,
-                "latte" => Theme::Latte,
-                _ => Theme::Mocha,
-            },
-            _ => Theme::Mocha,
+            "catppuccin" => Theme::Catppuccin(CatppuccinFlavor::resolve(&self.flavor)),
+            "rose-pine" | "rosepine" | "rose_pine" => {
+                Theme::RosePine(RosePineFlavor::resolve(&self.flavor))
+            }
+            "tokyo-night" | "tokyonight" | "tokyo_night" => {
+                Theme::TokyoNight(TokyoNightFlavor::resolve(&self.flavor))
+            }
+            _ => Theme::default(),
         }
     }
 }
 
 /// A resolved color theme used internally for color lookups.
 ///
-/// Obtained from [`ThemeConfig::resolve()`]. All color methods live
-/// here so the rest of the codebase doesn't need to know about
-/// theme names or flavors.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Each variant pairs a theme family with a flavor of that family,
+/// so invalid combinations (e.g. Rosé Pine with a Mocha flavor) are
+/// unrepresentable at the type level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Theme {
-    /// Catppuccin Mocha — dark theme with warm pastels.
+    /// Catppuccin (Mocha, Macchiato, Frappé, Latte).
+    Catppuccin(CatppuccinFlavor),
+    /// Rosé Pine (Main, Moon, Dawn).
+    RosePine(RosePineFlavor),
+    /// Tokyo Night (Night, Storm, Day).
+    TokyoNight(TokyoNightFlavor),
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self::Catppuccin(CatppuccinFlavor::Mocha)
+    }
+}
+
+/// Catppuccin flavors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CatppuccinFlavor {
+    /// Mocha -- dark theme with warm pastels (default).
     #[default]
     Mocha,
-    /// Catppuccin Macchiato — dark theme with muted tones.
+    /// Macchiato -- dark theme with muted tones.
     Macchiato,
-    /// Catppuccin Frappé — mid-tone dark theme.
+    /// Frappé -- mid-tone dark theme.
     Frappe,
-    /// Catppuccin Latte — light theme.
+    /// Latte -- light theme.
     Latte,
+}
+
+impl CatppuccinFlavor {
+    fn resolve(flavor: &str) -> Self {
+        match flavor.to_ascii_lowercase().as_str() {
+            "macchiato" => Self::Macchiato,
+            "frappe" | "frappé" => Self::Frappe,
+            "latte" => Self::Latte,
+            _ => Self::Mocha,
+        }
+    }
+}
+
+/// Rosé Pine flavors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RosePineFlavor {
+    /// Main -- the standard dark variant (default).
+    #[default]
+    Main,
+    /// Moon -- a slightly lighter dark variant.
+    Moon,
+    /// Dawn -- the light variant.
+    Dawn,
+}
+
+impl RosePineFlavor {
+    fn resolve(flavor: &str) -> Self {
+        match flavor.to_ascii_lowercase().as_str() {
+            "moon" => Self::Moon,
+            "dawn" => Self::Dawn,
+            _ => Self::Main,
+        }
+    }
+}
+
+/// Tokyo Night flavors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TokyoNightFlavor {
+    /// Night -- the standard dark variant (default).
+    #[default]
+    Night,
+    /// Storm -- darker variant with a bluish tint.
+    Storm,
+    /// Day -- the light variant.
+    Day,
+}
+
+impl TokyoNightFlavor {
+    fn resolve(flavor: &str) -> Self {
+        match flavor.to_ascii_lowercase().as_str() {
+            "storm" => Self::Storm,
+            "day" => Self::Day,
+            _ => Self::Night,
+        }
+    }
 }
 
 impl Theme {
@@ -81,45 +155,86 @@ impl Theme {
         palette::bar_colors(self)
     }
 
-    /// Returns the focused window border color (Catppuccin Blue).
+    /// Returns the focused window border color.
+    ///
+    /// Catppuccin uses Blue, Rosé Pine uses Iris (matching the bar
+    /// foreground), Tokyo Night uses its primary Blue accent. The
+    /// exact hex shifts per flavor so the highlight reads well
+    /// against each base background.
     pub fn border_focused(self) -> &'static str {
         match self {
-            Self::Mocha => "#89b4fa",
-            Self::Macchiato => "#8aadf4",
-            Self::Frappe => "#8caaee",
-            Self::Latte => "#1e66f5",
+            Self::Catppuccin(f) => match f {
+                CatppuccinFlavor::Mocha => "#89b4fa",
+                CatppuccinFlavor::Macchiato => "#8aadf4",
+                CatppuccinFlavor::Frappe => "#8caaee",
+                CatppuccinFlavor::Latte => "#1e66f5",
+            },
+            Self::RosePine(f) => match f {
+                // Iris matches the bar foreground so the focused
+                // window outline visually ties into the bar.
+                RosePineFlavor::Main | RosePineFlavor::Moon => "#c4a7e7",
+                RosePineFlavor::Dawn => "#907aa9",
+            },
+            Self::TokyoNight(f) => match f {
+                TokyoNightFlavor::Night | TokyoNightFlavor::Storm => "#7aa2f7",
+                TokyoNightFlavor::Day => "#2e7de9",
+            },
         }
     }
 
-    /// Returns the monocle window border color (Catppuccin Green).
+    /// Returns the monocle window border color.
+    ///
+    /// Catppuccin uses Green, Rosé Pine uses Foam, Tokyo Night uses
+    /// Green.
     pub fn border_monocle(self) -> &'static str {
         match self {
-            Self::Mocha => "#a6e3a1",
-            Self::Macchiato => "#a6da95",
-            Self::Frappe => "#a6d189",
-            Self::Latte => "#40a02b",
+            Self::Catppuccin(f) => match f {
+                CatppuccinFlavor::Mocha => "#a6e3a1",
+                CatppuccinFlavor::Macchiato => "#a6da95",
+                CatppuccinFlavor::Frappe => "#a6d189",
+                CatppuccinFlavor::Latte => "#40a02b",
+            },
+            Self::RosePine(f) => match f {
+                RosePineFlavor::Main | RosePineFlavor::Moon => "#9ccfd8",
+                RosePineFlavor::Dawn => "#56949f",
+            },
+            Self::TokyoNight(f) => match f {
+                TokyoNightFlavor::Night | TokyoNightFlavor::Storm => "#9ece6a",
+                TokyoNightFlavor::Day => "#587539",
+            },
         }
     }
 
-    /// Returns the unfocused window border color (Catppuccin Overlay0).
+    /// Returns the unfocused window border color.
     ///
     /// Chosen to be visible but understated against each theme's base
-    /// background, so unfocused tile boundaries remain readable
-    /// without competing with the focused-window highlight.
+    /// background. Catppuccin uses Overlay0, Rosé Pine uses Subtle,
+    /// Tokyo Night uses Comment.
     pub fn border_unfocused(self) -> &'static str {
         match self {
-            Self::Mocha => "#6c7086",
-            Self::Macchiato => "#6e738d",
-            Self::Frappe => "#737994",
-            Self::Latte => "#9ca0b0",
+            Self::Catppuccin(f) => match f {
+                CatppuccinFlavor::Mocha => "#6c7086",
+                CatppuccinFlavor::Macchiato => "#6e738d",
+                CatppuccinFlavor::Frappe => "#737994",
+                CatppuccinFlavor::Latte => "#9ca0b0",
+            },
+            Self::RosePine(f) => match f {
+                RosePineFlavor::Main | RosePineFlavor::Moon => "#908caa",
+                RosePineFlavor::Dawn => "#797593",
+            },
+            Self::TokyoNight(f) => match f {
+                TokyoNightFlavor::Night | TokyoNightFlavor::Storm => "#565f89",
+                TokyoNightFlavor::Day => "#848cb5",
+            },
         }
     }
 
-    /// Resolves a named Catppuccin color (e.g. "blue", "green") to its
-    /// hex value for this theme. Returns `None` for unknown names.
+    /// Resolves a named color (e.g. `"blue"`, `"pine"`) to its hex
+    /// value for this theme. Returns `None` for unknown names.
     ///
-    /// This allows users to write `focused = "blue"` instead of a hex
-    /// code, and mosaico picks the correct shade for the active theme.
+    /// This lets users write `focused = "blue"` instead of a hex
+    /// code and pick up the right shade for whichever theme they
+    /// happen to be using.
     pub fn named_color(self, name: &str) -> Option<&'static str> {
         palette::named_color(self, name)
     }
@@ -127,9 +242,9 @@ impl Theme {
     /// Resolves a color value that may be a hex code, a named color,
     /// or empty. Returns the resolved hex string.
     ///
-    /// - `""` → returns `fallback`
-    /// - `"blue"` → resolves via the theme palette
-    /// - `"#89b4fa"` → returned as-is
+    /// - `""` returns `fallback`
+    /// - `"blue"` resolves via the theme palette
+    /// - `"#89b4fa"` is returned as-is
     pub fn resolve_color<'a>(&self, value: &'a str, fallback: &'a str) -> &'a str {
         if value.is_empty() {
             return fallback;
@@ -150,23 +265,77 @@ mod tests {
         let tc = ThemeConfig::default();
         assert_eq!(tc.name, "catppuccin");
         assert_eq!(tc.flavor, "mocha");
-        assert_eq!(tc.resolve(), Theme::Mocha);
+        assert_eq!(tc.resolve(), Theme::Catppuccin(CatppuccinFlavor::Mocha));
     }
 
     #[test]
     fn resolve_all_catppuccin_flavors() {
         let cases = [
-            ("mocha", Theme::Mocha),
-            ("macchiato", Theme::Macchiato),
-            ("frappe", Theme::Frappe),
-            ("latte", Theme::Latte),
+            ("mocha", CatppuccinFlavor::Mocha),
+            ("macchiato", CatppuccinFlavor::Macchiato),
+            ("frappe", CatppuccinFlavor::Frappe),
+            ("latte", CatppuccinFlavor::Latte),
         ];
         for (flavor, expected) in cases {
             let tc = ThemeConfig {
                 name: "catppuccin".into(),
                 flavor: flavor.into(),
             };
-            assert_eq!(tc.resolve(), expected, "flavor {flavor}");
+            assert_eq!(tc.resolve(), Theme::Catppuccin(expected), "flavor {flavor}");
+        }
+    }
+
+    #[test]
+    fn resolve_rose_pine_flavors() {
+        let cases = [
+            ("main", RosePineFlavor::Main),
+            ("moon", RosePineFlavor::Moon),
+            ("dawn", RosePineFlavor::Dawn),
+        ];
+        for (flavor, expected) in cases {
+            let tc = ThemeConfig {
+                name: "rose-pine".into(),
+                flavor: flavor.into(),
+            };
+            assert_eq!(tc.resolve(), Theme::RosePine(expected), "flavor {flavor}");
+        }
+    }
+
+    #[test]
+    fn resolve_tokyo_night_flavors() {
+        let cases = [
+            ("night", TokyoNightFlavor::Night),
+            ("storm", TokyoNightFlavor::Storm),
+            ("day", TokyoNightFlavor::Day),
+        ];
+        for (flavor, expected) in cases {
+            let tc = ThemeConfig {
+                name: "tokyo-night".into(),
+                flavor: flavor.into(),
+            };
+            assert_eq!(tc.resolve(), Theme::TokyoNight(expected), "flavor {flavor}");
+        }
+    }
+
+    #[test]
+    fn rose_pine_name_aliases() {
+        for name in ["rose-pine", "rosepine", "rose_pine", "Rose-Pine"] {
+            let tc = ThemeConfig {
+                name: name.into(),
+                flavor: "main".into(),
+            };
+            assert_eq!(tc.resolve(), Theme::RosePine(RosePineFlavor::Main));
+        }
+    }
+
+    #[test]
+    fn tokyo_night_name_aliases() {
+        for name in ["tokyo-night", "tokyonight", "tokyo_night", "Tokyo-Night"] {
+            let tc = ThemeConfig {
+                name: name.into(),
+                flavor: "night".into(),
+            };
+            assert_eq!(tc.resolve(), Theme::TokyoNight(TokyoNightFlavor::Night));
         }
     }
 
@@ -176,32 +345,38 @@ mod tests {
             name: "Catppuccin".into(),
             flavor: "Latte".into(),
         };
-        assert_eq!(tc.resolve(), Theme::Latte);
+        assert_eq!(tc.resolve(), Theme::Catppuccin(CatppuccinFlavor::Latte));
     }
 
     #[test]
-    fn unknown_theme_falls_back_to_mocha() {
+    fn unknown_theme_falls_back_to_default() {
         let tc = ThemeConfig {
-            name: "tokyo".into(),
+            name: "tokyo".into(), // missing the -night
             flavor: "night".into(),
         };
-        assert_eq!(tc.resolve(), Theme::Mocha);
+        assert_eq!(tc.resolve(), Theme::default());
     }
 
     #[test]
-    fn unknown_flavor_falls_back_to_mocha() {
+    fn unknown_flavor_falls_back_to_family_default() {
         let tc = ThemeConfig {
             name: "catppuccin".into(),
             flavor: "espresso".into(),
         };
-        assert_eq!(tc.resolve(), Theme::Mocha);
+        assert_eq!(tc.resolve(), Theme::Catppuccin(CatppuccinFlavor::Mocha));
+
+        let tc = ThemeConfig {
+            name: "rose-pine".into(),
+            flavor: "midnight".into(),
+        };
+        assert_eq!(tc.resolve(), Theme::RosePine(RosePineFlavor::Main));
     }
 
     #[test]
     fn theme_config_round_trips_through_toml() {
         let tc = ThemeConfig {
-            name: "catppuccin".into(),
-            flavor: "frappe".into(),
+            name: "rose-pine".into(),
+            flavor: "moon".into(),
         };
         let toml_str = toml::to_string(&tc).unwrap();
         let parsed: ThemeConfig = toml::from_str(&toml_str).unwrap();
@@ -209,8 +384,8 @@ mod tests {
     }
 
     #[test]
-    fn mocha_colors_match_catppuccin() {
-        let c = Theme::Mocha.bar_colors();
+    fn mocha_bar_colors_match_catppuccin() {
+        let c = Theme::Catppuccin(CatppuccinFlavor::Mocha).bar_colors();
         assert_eq!(c.background, "#1e1e2e");
         assert_eq!(c.foreground, "#89b4fa");
         assert_eq!(c.active_workspace, "#435375");
@@ -219,57 +394,114 @@ mod tests {
 
     #[test]
     fn latte_is_light_theme() {
-        let c = Theme::Latte.bar_colors();
+        let c = Theme::Catppuccin(CatppuccinFlavor::Latte).bar_colors();
         assert_eq!(c.background, "#eff1f5");
         assert_eq!(c.foreground, "#1e66f5");
     }
 
     #[test]
-    fn border_colors_match_theme() {
-        assert_eq!(Theme::Mocha.border_focused(), "#89b4fa");
-        assert_eq!(Theme::Mocha.border_monocle(), "#a6e3a1");
-        assert_eq!(Theme::Latte.border_focused(), "#1e66f5");
-        assert_eq!(Theme::Latte.border_monocle(), "#40a02b");
+    fn rose_pine_main_bar_features_iris_and_rose() {
+        // The bar foreground and the focused window border share
+        // Iris (purple) so the focused window visually ties into the
+        // bar's lead color.
+        let c = Theme::RosePine(RosePineFlavor::Main).bar_colors();
+        assert_eq!(c.background, "#191724"); // Base
+        assert_eq!(c.foreground, "#c4a7e7"); // Iris
+        assert_eq!(c.accent, "#ebbcba"); // Rose
+        assert_eq!(
+            Theme::RosePine(RosePineFlavor::Main).border_focused(),
+            c.foreground
+        );
     }
 
     #[test]
-    fn unfocused_border_is_distinct_per_theme() {
-        // Each theme picks a muted gray drawn from its own palette
-        // (Catppuccin Overlay0).
-        let cases = [
-            (Theme::Mocha, "#6c7086"),
-            (Theme::Macchiato, "#6e738d"),
-            (Theme::Frappe, "#737994"),
-            (Theme::Latte, "#9ca0b0"),
+    fn tokyo_night_bar_uses_blue_accent() {
+        let c = Theme::TokyoNight(TokyoNightFlavor::Night).bar_colors();
+        assert_eq!(c.background, "#1a1b26");
+        assert_eq!(c.foreground, "#7aa2f7");
+    }
+
+    #[test]
+    fn border_focused_matches_per_flavor() {
+        assert_eq!(
+            Theme::Catppuccin(CatppuccinFlavor::Mocha).border_focused(),
+            "#89b4fa"
+        );
+        // Rose Pine matches its bar foreground (Iris).
+        assert_eq!(
+            Theme::RosePine(RosePineFlavor::Main).border_focused(),
+            "#c4a7e7"
+        );
+        assert_eq!(
+            Theme::TokyoNight(TokyoNightFlavor::Night).border_focused(),
+            "#7aa2f7"
+        );
+    }
+
+    #[test]
+    fn rose_pine_focus_border_matches_bar_foreground() {
+        // Every Rose Pine flavor's focused border equals its bar
+        // foreground so the highlight is consistent across the UI.
+        for flavor in [
+            RosePineFlavor::Main,
+            RosePineFlavor::Moon,
+            RosePineFlavor::Dawn,
+        ] {
+            let theme = Theme::RosePine(flavor);
+            assert_eq!(
+                theme.border_focused(),
+                theme.bar_colors().foreground,
+                "flavor {flavor:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn border_unfocused_distinct_from_focused_for_every_theme() {
+        let themes = [
+            Theme::Catppuccin(CatppuccinFlavor::Mocha),
+            Theme::Catppuccin(CatppuccinFlavor::Macchiato),
+            Theme::Catppuccin(CatppuccinFlavor::Frappe),
+            Theme::Catppuccin(CatppuccinFlavor::Latte),
+            Theme::RosePine(RosePineFlavor::Main),
+            Theme::RosePine(RosePineFlavor::Moon),
+            Theme::RosePine(RosePineFlavor::Dawn),
+            Theme::TokyoNight(TokyoNightFlavor::Night),
+            Theme::TokyoNight(TokyoNightFlavor::Storm),
+            Theme::TokyoNight(TokyoNightFlavor::Day),
         ];
-        for (theme, hex) in cases {
-            assert_eq!(theme.border_unfocused(), hex, "theme {theme:?}");
-            // Sanity: distinct from the theme's focused and monocle
-            // colors so the unfocused state is visually different.
-            assert_ne!(theme.border_unfocused(), theme.border_focused());
-            assert_ne!(theme.border_unfocused(), theme.border_monocle());
+        for t in themes {
+            assert_ne!(t.border_focused(), t.border_unfocused(), "theme {t:?}");
+            assert_ne!(t.border_monocle(), t.border_unfocused(), "theme {t:?}");
         }
     }
 
     #[test]
     fn resolve_color_handles_all_cases() {
-        let t = Theme::Mocha;
-        // Empty → fallback
+        let t = Theme::Catppuccin(CatppuccinFlavor::Mocha);
         assert_eq!(t.resolve_color("", "#default"), "#default");
-        // Hex → as-is
         assert_eq!(t.resolve_color("#ff0000", "#default"), "#ff0000");
-        // Named → resolved
         assert_eq!(t.resolve_color("blue", "#default"), "#89b4fa");
-        // Unknown name → as-is
         assert_eq!(t.resolve_color("chartreuse", "#default"), "chartreuse");
     }
 
     #[test]
     fn each_theme_has_distinct_base() {
-        let bases: Vec<String> = [Theme::Mocha, Theme::Macchiato, Theme::Frappe, Theme::Latte]
-            .iter()
-            .map(|t| t.bar_colors().background.clone())
-            .collect();
+        let bases: Vec<String> = [
+            Theme::Catppuccin(CatppuccinFlavor::Mocha),
+            Theme::Catppuccin(CatppuccinFlavor::Macchiato),
+            Theme::Catppuccin(CatppuccinFlavor::Frappe),
+            Theme::Catppuccin(CatppuccinFlavor::Latte),
+            Theme::RosePine(RosePineFlavor::Main),
+            Theme::RosePine(RosePineFlavor::Moon),
+            Theme::RosePine(RosePineFlavor::Dawn),
+            Theme::TokyoNight(TokyoNightFlavor::Night),
+            Theme::TokyoNight(TokyoNightFlavor::Storm),
+            Theme::TokyoNight(TokyoNightFlavor::Day),
+        ]
+        .iter()
+        .map(|t| t.bar_colors().background.clone())
+        .collect();
         for (i, a) in bases.iter().enumerate() {
             for (j, b) in bases.iter().enumerate() {
                 if i != j {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,10 @@ unfocused = "#6c7086"  # Color drawn around unfocused tiled windows
                        # (set to "none" to disable unfocused borders)
 
 [theme]
-flavor = "mocha"   # Catppuccin flavor: latte, frappe, macchiato, mocha
+name = "catppuccin"  # catppuccin, rose-pine, tokyo-night
+flavor = "mocha"     # catppuccin: mocha | macchiato | frappe | latte
+                     # rose-pine:  main | moon | dawn
+                     # tokyo-night: night | storm | day
 
 [logging]
 enabled = false    # Enable file logging

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -19,22 +19,39 @@ and the status bar -- from a single configuration line.
 
 - `ThemeConfig` -- user-facing config: `name: String` (default `"catppuccin"`),
   `flavor: String` (default `"mocha"`)
-- `Theme` -- resolved enum: `Mocha`, `Macchiato`, `Frappe`, `Latte`
+- `Theme` -- resolved enum, one variant per family carrying its
+  flavor enum: `Catppuccin(CatppuccinFlavor)`, `RosePine(RosePineFlavor)`,
+  `TokyoNight(TokyoNightFlavor)`. The nesting keeps invalid
+  combinations (e.g. Rosé Pine with a Mocha flavor) unrepresentable
+  at the type level
+- `CatppuccinFlavor` -- `Mocha` (default), `Macchiato`, `Frappe`, `Latte`
+- `RosePineFlavor` -- `Main` (default), `Moon`, `Dawn`
+- `TokyoNightFlavor` -- `Night` (default), `Storm`, `Day`
 
-## Catppuccin Flavors
+## Theme Families
 
-| Flavor | Description |
-|--------|-------------|
-| Latte | Light theme |
-| Frappe | Mid-light dark theme |
-| Macchiato | Mid-dark theme |
-| Mocha | Darkest theme (default) |
+| Family | Flavors | Style |
+|--------|---------|-------|
+| Catppuccin | Latte / Frappé / Macchiato / Mocha | Light through darkest |
+| Rosé Pine | Main / Moon / Dawn | Two darks, one light |
+| Tokyo Night | Night / Storm / Day | Two darks, one light |
 
-Each flavor provides 14 named accent colors, all compiled into the binary
-as constants in `palette.rs`:
+Each flavor has its own named-color table and bar color mapping,
+defined in `crates/mosaico-core/src/config/palette/<family>.rs`.
 
-Rosewater, Flamingo, Pink, Mauve, Red, Maroon, Peach, Yellow, Green, Teal,
-Sky, Sapphire, Blue, Lavender
+### Common Color Aliases
+
+To keep portable configs (`focused = "blue"`) working across themes,
+every family exposes the four most common color names: `red`, `blue`,
+`green`, `yellow`. The exact shade differs per theme so the highlight
+reads well against that theme's base background.
+
+Catppuccin additionally exposes 14 native accent colors (rosewater,
+flamingo, pink, mauve, red, maroon, peach, yellow, green, teal, sky,
+sapphire, blue, lavender). Rosé Pine exposes its six native names
+(love, gold, rose, pine, foam, iris). Tokyo Night exposes red, orange,
+yellow, green, cyan, teal, blue, purple plus aliases `mauve` and
+`magenta` for `purple`.
 
 ## Named Color Resolution
 
@@ -79,7 +96,8 @@ This applies to border colors in `config.toml` and all color fields in
 | Widget background | `#313244` (Surface0) |
 | Pill border | `#45475a` (Surface1) |
 
-Each flavor has its own complete bar color palette defined in `palette.rs`.
+Each flavor has its own complete bar color palette defined in
+`palette/<family>.rs` (one file per theme family).
 
 ## Configuration
 
@@ -87,11 +105,22 @@ In `config.toml`:
 
 ```toml
 [theme]
-name = "catppuccin"
-flavor = "mocha"       # latte, frappe, macchiato, mocha
+name = "catppuccin"   # catppuccin, rose-pine, tokyo-night
+flavor = "mocha"
 ```
 
-Flavor names are case-insensitive. Unknown values fall back to Mocha.
+Recognized name + flavor combinations:
+
+| name | flavor |
+|------|--------|
+| `catppuccin` | `mocha`, `macchiato`, `frappe`, `latte` |
+| `rose-pine` (alias `rosepine`, `rose_pine`) | `main`, `moon`, `dawn` |
+| `tokyo-night` (alias `tokyonight`, `tokyo_night`) | `night`, `storm`, `day` |
+
+Both name and flavor are case-insensitive. Unknown values fall back
+to the family default (e.g. `name = "rose-pine"` with an unknown
+flavor resolves to Main); unknown family names fall back to Catppuccin
+Mocha.
 
 ## Color Precedence
 

--- a/website/src/guide/configuration.md
+++ b/website/src/guide/configuration.md
@@ -49,7 +49,10 @@ unfocused = "#6c7086"  # Color drawn around unfocused tiled windows;
                        # set to "none" to disable unfocused borders
 
 [theme]
-flavor = "mocha"   # Catppuccin flavor: latte, frappe, macchiato, mocha
+name = "catppuccin"  # catppuccin, rose-pine, tokyo-night
+flavor = "mocha"     # catppuccin: mocha | macchiato | frappe | latte
+                     # rose-pine:  main | moon | dawn
+                     # tokyo-night: night | storm | day
 
 [logging]
 enabled = false    # Enable file logging

--- a/website/src/guide/theming.md
+++ b/website/src/guide/theming.md
@@ -1,32 +1,57 @@
 # Theming
 
-Mosaico includes a built-in theme system based on the
-[Catppuccin](https://catppuccin.com/) color palette. Themes provide a
-consistent color scheme across focus borders, monocle borders, and the
-status bar.
+Mosaico ships with three built-in theme families: [Catppuccin](https://catppuccin.com/),
+[Rosé Pine](https://rosepinetheme.com/), and [Tokyo Night](https://github.com/folke/tokyonight.nvim).
+Each family has multiple flavors that share a common palette and only differ
+in shading, so the focus borders, monocle border, unfocused borders, and the
+status bar all stay coordinated.
 
 ## Configuration
 
-Set the theme flavor in `config.toml`:
+Set the theme name and flavor in `config.toml`:
 
 ```toml
 [theme]
-flavor = "mocha"   # latte, frappe, macchiato, mocha
+name = "catppuccin"   # catppuccin, rose-pine, tokyo-night
+flavor = "mocha"
 ```
 
-## Available Flavors
+## Available Themes
+
+### Catppuccin
 
 | Flavor | Style |
 |--------|-------|
-| `latte` | Light theme |
-| `frappe` | Medium-dark theme |
-| `macchiato` | Dark theme |
-| `mocha` | Darkest theme (default) |
+| `latte` | Light |
+| `frappe` | Medium-dark |
+| `macchiato` | Dark |
+| `mocha` | Darkest (default) |
+
+### Rosé Pine (`name = "rose-pine"`)
+
+| Flavor | Style |
+|--------|-------|
+| `main` | Dark, default |
+| `moon` | Slightly lighter dark |
+| `dawn` | Light |
+
+### Tokyo Night (`name = "tokyo-night"`)
+
+| Flavor | Style |
+|--------|-------|
+| `night` | Dark, default |
+| `storm` | Dark with bluish tint |
+| `day` | Light |
 
 ## Named Colors
 
 When a theme is active, you can use named colors anywhere a color value is
-expected (borders, bar colors). The following 14 accent colors are available:
+expected (borders, bar colors). Each theme family exposes its own palette,
+plus a small set of common aliases (`red`, `green`, `blue`, `yellow`) that
+resolve under every theme so portable configs like `focused = "blue"` look
+right regardless of which theme you pick.
+
+### Catppuccin (14 accent colors)
 
 | Name | Description |
 |------|-------------|
@@ -44,6 +69,30 @@ expected (borders, bar colors). The following 14 accent colors are available:
 | `sapphire` | Blue |
 | `blue` | Vivid blue |
 | `lavender` | Soft purple |
+
+### Rosé Pine
+
+| Name | Description |
+|------|-------------|
+| `love` | Red/pink accent (alias `red`) |
+| `gold` | Warm yellow (alias `yellow`) |
+| `rose` | Soft pink |
+| `pine` | Teal/blue accent (alias `blue`) |
+| `foam` | Cyan (alias `green`, `teal`) |
+| `iris` | Purple (alias `mauve`, `purple`, `magenta`) |
+
+### Tokyo Night
+
+| Name | Description |
+|------|-------------|
+| `red` | Red |
+| `orange` | Orange |
+| `yellow` | Yellow |
+| `green` | Green |
+| `cyan` | Cyan |
+| `teal` | Teal |
+| `blue` | Blue |
+| `purple` | Purple (alias `mauve`, `magenta`) |
 
 Additional named colors for surfaces and text:
 


### PR DESCRIPTION
## Summary

Mosaico now ships three theme families: Catppuccin (existing), Rosé Pine (new), and Tokyo Night (new). Each family has multiple flavors that share a common palette and only differ in shading.

```toml
[theme]
name = "catppuccin"   # catppuccin, rose-pine, tokyo-night
flavor = "mocha"
```

| name | flavor |
|------|--------|
| `catppuccin` | `mocha` (default), `macchiato`, `frappe`, `latte` |
| `rose-pine` (alias `rosepine`, `rose_pine`) | `main` (default), `moon`, `dawn` |
| `tokyo-night` (alias `tokyonight`, `tokyo_night`) | `night` (default), `storm`, `day` |

All names and flavors are case-insensitive. Unknown family names fall back to Catppuccin Mocha; unknown flavors fall back to the family default.

## Type-level cleanup

The `Theme` enum is now nested -- one variant per family carrying its own flavor enum -- so invalid combinations (Rosé Pine with a Mocha flavor, etc.) are unrepresentable:

```rust
pub enum Theme {
    Catppuccin(CatppuccinFlavor),
    RosePine(RosePineFlavor),
    TokyoNight(TokyoNightFlavor),
}
```

Each flavor enum has its own `Default` matching the family's canonical default.

## Palette module split

`palette.rs` is promoted to a `palette/` module with one file per family (`catppuccin.rs`, `rose_pine.rs`, `tokyo_night.rs`) plus a dispatcher in `mod.rs`. Each family file holds its own named-color table and bar color mapping, and stays under the project's ~150 line guideline.

## Bar identity choices

- **Rosé Pine bars** lead with **Iris** (purple) for foreground/pill borders and **Rose** (the namesake) for the secondary accent. The focused window border also uses **Iris** so the highlight ties into the bar's lead color: `#c4a7e7` for Main and Moon (canonical -- they share the Iris hex upstream), `#907aa9` for Dawn.
- **Tokyo Night Night/Storm** bars lead with the upstream Blue (`#7aa2f7`) and Green (`#9ece6a`). **Day** uses upstream Day blue (`#2e7de9`) and Day green (`#587539`).

## Common color aliases

Every family exposes `red`, `blue`, `green`, `yellow` so portable configs (`focused = "blue"`) resolve under any theme. Family-specific names (`pine`, `iris`, `magenta`, ...) only resolve under their own family.

Tokyo Night `purple`/`magenta`/`teal` and the entire Day flavor are aligned to current `tokyonight.nvim` (`purple = #9d7cd8`, `magenta = #bb9af7`, `teal = #1abc9c` Night/Storm, `red = #f52a65` Day, etc.).

## Tests

- **Theme**: per-family `resolve_*` tests, name aliases, case-insensitivity, unknown-name fallback, unknown-flavor fallback, TOML round-trip, distinct bar background per theme, distinct border colors per state, Rosé Pine bar leads with Iris and Rose, Rosé Pine focus border equals bar foreground for every flavor.
- **Palette**: per-family table size and alias coverage, common aliases resolve in every theme, family-specific names do not leak across families, Tokyo Night purple/magenta and Day red sanity checks.
- 241 lib tests total. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Docs

`docs/configuration.md`, `docs/theming.md`, `website/src/guide/configuration.md`, `website/src/guide/theming.md`, and the `mosaico init` template all updated to cover the three families and their flavors.

A new planning doc, `.plans/phase-33.md` (Theme Accent Override), captures the follow-up work to let users pick a custom palette accent in one line (e.g. `accent = "gold"` under Rosé Pine to swap Iris for Gold across the bar lead and focus border). Not part of this PR.

## Behavior change

None for existing users. `Theme::default()` still returns Catppuccin Mocha, and configs without a `[theme]` section behave exactly as before. The new theme families are opt-in via the `name` field.

## Test plan

- [ ] Set `name = "rose-pine"` / `flavor = "main"` and start the daemon. Confirm the bar reads purple-rose (Iris foreground, Rose accent) and the focus border is the same Iris purple `#c4a7e7`.
- [ ] Set `flavor = "moon"` and `flavor = "dawn"`. Confirm distinct backgrounds (`#232136`, `#faf4ed`) and that Dawn uses the lighter Iris/Rose shades (`#907aa9` / `#d7827e`).
- [ ] Set `name = "tokyo-night"` / `flavor = "night"`. Confirm bar reads Blue with a Green accent and the focus border is `#7aa2f7`.
- [ ] Set `flavor = "day"`. Confirm light theme background (`#e1e2e7`) and the upstream Day blue/green hexes (`#2e7de9`, `#587539`).
- [ ] Verify name aliases (`rosepine`, `tokyonight`, etc.) and case-insensitive flavor names resolve correctly.
- [ ] Verify unknown name (e.g. `name = "tokyo"`) falls back to Catppuccin Mocha and unknown flavor (e.g. `name = "rose-pine"`, `flavor = "espresso"`) falls back to that family's default (Main).
- [ ] Confirm a config with `[borders.colors] focused = "blue"` renders correctly under all three families (each picks its family's "blue").
