### PR TITLE
docs: add cheatsheet page and refresh user-facing guides

### DIFF
--- a/website/src/README.md
+++ b/website/src/README.md
@@ -2,27 +2,37 @@
 
 A cross-platform tiling window manager, written in Rust.
 
+<img alt="Mosaico screenshot" src="https://github.com/user-attachments/assets/13b02a9c-cbd5-4fc7-9498-f3399556fc7d" />
+
 Mosaico automatically arranges your windows into a non-overlapping tiled
-layout using a Binary Space Partitioning (BSP) algorithm. It runs as a
-lightweight background daemon and is controlled entirely from the command
-line or via global keyboard shortcuts.
+layout. It ships three tiling algorithms (BSP, VerticalStack, ThreeColumn)
+that you can cycle per workspace at runtime, runs as a lightweight
+background daemon, and is controlled entirely from the command line or
+via global keyboard shortcuts.
 
 ## Features
 
-- **Automatic tiling** -- windows are arranged in a BSP layout the moment
-  they open, close, or are moved between monitors.
+- **Automatic tiling with three algorithms** -- BSP (default),
+  VerticalStack, and ThreeColumn. Cycle on the fly with `Alt + N` or
+  pin a layout per workspace.
 - **Vim-style navigation** -- focus and move windows with `Alt + H/J/K/L`.
 - **Workspaces** -- up to 8 workspaces, switching either per-monitor
   (default) or globally across every display, like Windows virtual desktops.
 - **Multi-monitor** -- each monitor is managed independently with
   cross-monitor navigation.
-- **Focus borders** -- colored overlay border around the focused window.
+- **Per-window borders** -- focused, monocle, and unfocused color states
+  under `[borders.colors]`.
 - **Monocle mode** -- full-screen single-window mode per monitor.
 - **Status bar** -- configurable per-monitor bar with workspace indicators,
-  clock, CPU, RAM, and more.
-- **Catppuccin theming** -- built-in theme system with four flavors.
-- **Hot-reload** -- configuration changes are applied without restarting.
-- **Window rules** -- exclude specific applications from tiling.
+  clock, CPU, RAM, focused window icon, pause indicator, and more.
+- **Three theme families** -- Catppuccin, Rosé Pine, and Tokyo Night
+  with multiple flavors each.
+- **Pause / unpause hotkeys** -- `Alt + Shift + P` releases every Mosaico
+  shortcut so full-screen applications can claim the same combinations.
+- **Hot-reload** -- changes to `config.toml`, `bar.toml`, and
+  `user-rules.toml` are applied without restarting.
+- **Window rules** -- community-maintained rules plus user overrides to
+  exclude specific applications from tiling.
 
 ## Quick Start
 

--- a/website/src/SUMMARY.md
+++ b/website/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Installation](guide/installation.md)
 - [Getting Started](guide/getting-started.md)
+- [Cheatsheet](guide/cheatsheet.md)
 - [CLI Commands](guide/cli.md)
 - [Configuration](guide/configuration.md)
     - [Keyboard Bindings](guide/keybindings.md)

--- a/website/src/guide/cheatsheet.md
+++ b/website/src/guide/cheatsheet.md
@@ -1,0 +1,181 @@
+# Cheatsheet
+
+A one-page reference for the default Mosaico keyboard shortcuts and CLI
+actions. Print it, pin it, or just keep this tab open.
+
+> **Tip:** every shortcut shown here can be remapped in
+> `~/.config/mosaico/keybindings.toml`. See
+> [Keyboard Bindings](keybindings.md) for the full configuration
+> reference.
+
+## At a Glance
+
+```
+Alt + H/J/K/L            focus left/down/up/right
+Alt + Shift + H/J/K/L    move/swap window left/down/up/right
+Alt + 1 .. Alt + 8       switch to workspace N
+Alt + Shift + 1 .. 8     send focused window to workspace N
+Alt + N                  cycle layout (BSP -> VStack -> 3Col)
+Alt + T                  toggle monocle (full-screen one window)
+Alt + M                  minimize focused window
+Alt + Q                  close focused window
+Alt + Shift + R          retile (re-apply current layout)
+Alt + Shift + P          pause / unpause all mosaico hotkeys
+```
+
+## Focus
+
+Move keyboard focus between tiled windows. Left and right cross monitors
+when no neighbor exists in that direction; up and down stay on the
+current monitor.
+
+| Shortcut | Action | CLI |
+|----------|--------|-----|
+| `Alt + H` | Focus left | `mosaico action focus left` |
+| `Alt + J` | Focus down | `mosaico action focus down` |
+| `Alt + K` | Focus up | `mosaico action focus up` |
+| `Alt + L` | Focus right | `mosaico action focus right` |
+
+## Move
+
+Swap the focused window with its neighbor in the given direction. Left
+and right can move a window between adjacent monitors; up and down swap
+within the same monitor.
+
+| Shortcut | Action | CLI |
+|----------|--------|-----|
+| `Alt + Shift + H` | Move left | `mosaico action move left` |
+| `Alt + Shift + J` | Move down | `mosaico action move down` |
+| `Alt + Shift + K` | Move up | `mosaico action move up` |
+| `Alt + Shift + L` | Move right | `mosaico action move right` |
+
+## Workspaces
+
+Each monitor has up to 8 workspaces. The default mode is *per-monitor*:
+switching workspace only affects the focused monitor. Set
+`workspaces.mode = "global"` in `config.toml` to flip every monitor in
+lockstep, like Windows virtual desktops. See
+[Workspaces](workspaces.md).
+
+| Shortcut | Action | CLI |
+|----------|--------|-----|
+| `Alt + 1` | Switch to workspace 1 | `mosaico action goto-workspace-1` |
+| `Alt + 2` | Switch to workspace 2 | `mosaico action goto-workspace-2` |
+| ... | ... | ... |
+| `Alt + 8` | Switch to workspace 8 | `mosaico action goto-workspace-8` |
+| `Alt + Shift + 1` | Send window to workspace 1 | `mosaico action send-to-workspace-1` |
+| `Alt + Shift + 2` | Send window to workspace 2 | `mosaico action send-to-workspace-2` |
+| ... | ... | ... |
+| `Alt + Shift + 8` | Send window to workspace 8 | `mosaico action send-to-workspace-8` |
+
+## Layout
+
+Cycle through Mosaico's three tiling algorithms or switch the focused
+workspace into monocle mode (one window fills the work area). Retile
+forces a fresh re-application of the current layout.
+
+| Shortcut | Action | CLI |
+|----------|--------|-----|
+| `Alt + N` | Cycle layout (BSP -> VerticalStack -> ThreeColumn -> ...) | `mosaico action cycle-layout` |
+| `Alt + T` | Toggle monocle mode | `mosaico action toggle-monocle` |
+| `Alt + Shift + R` | Retile | `mosaico action retile` |
+
+Per-workspace layout overrides are configured under
+`[workspaces.layouts]` in `config.toml`. See
+[Tiling & Layouts](tiling-layout.md).
+
+## Window
+
+| Shortcut | Action | CLI |
+|----------|--------|-----|
+| `Alt + Q` | Close focused window | `mosaico action close-focused` |
+| `Alt + M` | Minimize focused window | `mosaico action minimize-focused` |
+
+## Daemon
+
+Pause every Mosaico hotkey (including the pause hotkey itself stays
+active so you can resume) when running a full-screen application that
+needs to claim its own keybindings. The status bar shows a red `PAUSED`
+pill while paused.
+
+| Shortcut | Action | CLI |
+|----------|--------|-----|
+| `Alt + Shift + P` | Toggle pause / resume | `mosaico pause` / `mosaico unpause` |
+| -- | Start the daemon | `mosaico start` |
+| -- | Stop the daemon | `mosaico stop` |
+| -- | Check status | `mosaico status` |
+| -- | Reload config (automatic) | edit `config.toml`, save |
+| -- | Diagnose setup | `mosaico doctor` |
+
+## Modifier Keys
+
+| Keyword | Key |
+|---------|-----|
+| `alt` | Alt |
+| `shift` | Shift |
+| `ctrl` | Control |
+| `win` | Windows / Super |
+
+Combine in `keybindings.toml` with
+`modifiers = ["alt", "shift"]`.
+
+## Recognised Key Names
+
+| Type | Examples |
+|------|----------|
+| Letters | `A` .. `Z` (case-insensitive) |
+| Digits | `0` .. `9` |
+| Function | `F1` .. `F12` |
+| Named | `Enter`, `Escape`, `Tab`, `Space`, `Backspace`, `Delete`, `Insert`, `Home`, `End`, `PageUp`, `PageDown`, `Up`, `Down`, `Left`, `Right` |
+
+Set them in `~/.config/mosaico/keybindings.toml` like this:
+
+```toml
+[[keybinding]]
+action = "focus-left"
+key = "H"
+modifiers = ["alt"]
+
+[[keybinding]]
+action = "send-to-workspace-3"
+key = "3"
+modifiers = ["alt", "shift"]
+```
+
+## Themes at a Glance
+
+```toml
+[theme]
+name = "catppuccin"   # catppuccin, rose-pine, tokyo-night
+flavor = "mocha"      # depends on family (see below)
+```
+
+| Family | Flavors |
+|--------|---------|
+| `catppuccin` | `mocha`, `macchiato`, `frappe`, `latte` |
+| `rose-pine` | `main`, `moon`, `dawn` |
+| `tokyo-night` | `night`, `storm`, `day` |
+
+See [Theming](theming.md) for palette colors per family.
+
+## Border Colors at a Glance
+
+```toml
+[borders]
+width = 4              # 0 disables every border
+corner_style = "small" # square / small / round
+
+[borders.colors]
+focused = ""           # empty = theme default
+monocle = ""           # empty = theme default
+unfocused = ""         # empty = theme default; "none" disables unfocused borders
+```
+
+See [Focus Borders](focus-border.md) for the full lifecycle.
+
+## See Also
+
+- [Configuration](configuration.md) -- every config field, all four files.
+- [Keyboard Bindings](keybindings.md) -- full action reference and how to
+  remap.
+- [CLI Commands](cli.md) -- start, stop, status, action, doctor, ...

--- a/website/src/guide/getting-started.md
+++ b/website/src/guide/getting-started.md
@@ -38,21 +38,35 @@ The default keybindings use vim-style motions:
 
 | Shortcut | Action |
 |----------|--------|
-| `Alt + H` | Focus the window to the left |
-| `Alt + J` | Focus the window below |
-| `Alt + K` | Focus the window above |
-| `Alt + L` | Focus the window to the right |
-| `Alt + Shift + H` | Move window left |
-| `Alt + Shift + J` | Move window down |
-| `Alt + Shift + K` | Move window up |
-| `Alt + Shift + L` | Move window right |
-| `Alt + Shift + R` | Re-apply the tiling layout |
+| `Alt + H/J/K/L` | Focus left/down/up/right |
+| `Alt + Shift + H/J/K/L` | Move or swap the focused window |
+| `Alt + 1` .. `Alt + 8` | Switch to workspace 1-8 |
+| `Alt + Shift + 1` .. `Alt + Shift + 8` | Send focused window to workspace 1-8 |
+| `Alt + N` | Cycle layout (BSP / VerticalStack / ThreeColumn) |
 | `Alt + T` | Toggle monocle (full-screen) mode |
+| `Alt + M` | Minimize the focused window |
 | `Alt + Q` | Close the focused window |
-| `Alt + 1-8` | Switch to workspace 1-8 |
-| `Alt + Shift + 1-8` | Send focused window to workspace 1-8 |
+| `Alt + Shift + R` | Retile (re-apply the current layout) |
+| `Alt + Shift + P` | Pause / resume all Mosaico hotkeys |
 
-## 4. Check the Status
+The full reference card lives at the [Cheatsheet](cheatsheet.md). Edit
+`~/.config/mosaico/keybindings.toml` to remap any shortcut.
+
+## 4. Pick a Theme (optional)
+
+Mosaico ships with three theme families that color the status bar and
+the focus border. Set the active theme in `~/.config/mosaico/config.toml`:
+
+```toml
+[theme]
+name = "rose-pine"   # catppuccin (default), rose-pine, tokyo-night
+flavor = "main"
+```
+
+Save and the colors update live, no restart needed. See
+[Theming](theming.md) for the full palette per family.
+
+## 5. Check the Status
 
 ```sh
 mosaico status
@@ -60,7 +74,7 @@ mosaico status
 
 Reports whether the daemon is running and its PID.
 
-## 5. Run the Doctor
+## 6. Run the Doctor
 
 ```sh
 mosaico doctor
@@ -69,7 +83,7 @@ mosaico doctor
 Performs a health check on your configuration files, daemon status, and
 monitor setup. Any issues are reported with colored status tags.
 
-## 6. Stop the Window Manager
+## 7. Stop the Window Manager
 
 ```sh
 mosaico stop
@@ -79,7 +93,10 @@ All windows are restored to their original state before the daemon exits.
 
 ## Next Steps
 
+- [Cheatsheet](cheatsheet.md) -- one-page reference card for every default shortcut
 - [CLI Commands](cli.md) -- full command reference
 - [Configuration](configuration.md) -- customize layout, borders, and more
 - [Keyboard Bindings](keybindings.md) -- change or add shortcuts
-- [Workspaces](workspaces.md) -- learn about multi-workspace support
+- [Workspaces](workspaces.md) -- per-monitor and global workspace modes
+- [Focus Borders](focus-border.md) -- focused, monocle, and unfocused border colors
+- [Theming](theming.md) -- Catppuccin, Rosé Pine, Tokyo Night palettes

--- a/website/src/guide/keybindings.md
+++ b/website/src/guide/keybindings.md
@@ -7,7 +7,8 @@ application has focus. Keybindings are configured in
 ## Default Keybindings
 
 The defaults use vim-style spatial navigation (H=left, J=down, K=up,
-L=right):
+L=right). For a printable one-page reference, see the
+[Cheatsheet](cheatsheet.md).
 
 | Shortcut | Action |
 |----------|--------|
@@ -22,9 +23,11 @@ L=right):
 | `Alt + Shift + R` | Retile |
 | `Alt + T` | Toggle monocle |
 | `Alt + N` | Cycle layout |
+| `Alt + M` | Minimize focused window |
 | `Alt + Q` | Close focused window |
-| `Alt + 1` -- `Alt + 8` | Switch to workspace 1-8 |
-| `Alt + Shift + 1` -- `Alt + Shift + 8` | Send window to workspace 1-8 |
+| `Alt + 1` .. `Alt + 8` | Switch to workspace 1-8 |
+| `Alt + Shift + 1` .. `Alt + Shift + 8` | Send window to workspace 1-8 |
+| `Alt + Shift + P` | Toggle pause / resume |
 
 ## Configuration Format
 
@@ -56,8 +59,9 @@ modifiers = ["alt", "shift"]
 | `move-down` | Move window down |
 | `retile` | Re-apply the tiling layout |
 | `toggle-monocle` | Toggle monocle (full-screen) mode |
-| `cycle-layout` | Cycle to the next tiling layout |
+| `cycle-layout` | Cycle to the next tiling layout (BSP -> VStack -> 3Col) |
 | `close-focused` | Close the focused window |
+| `minimize-focused` | Minimize the focused window |
 | `goto-workspace-N` | Switch to workspace N (1-8) |
 | `send-to-workspace-N` | Send focused window to workspace N (1-8) |
 | `toggle-pause` | Toggle hotkey pause on/off |

--- a/website/src/guide/multi-monitor.md
+++ b/website/src/guide/multi-monitor.md
@@ -4,6 +4,11 @@ Mosaico manages each monitor independently with its own workspaces, layout,
 and monocle state. Windows can be navigated and moved across monitors
 seamlessly.
 
+By default, switching workspaces only flips the focused monitor (per-monitor
+mode). Set `workspaces.mode = "global"` in `config.toml` to make every
+monitor switch to the same workspace number in lockstep, like Windows
+virtual desktops. See [Workspaces -> Workspace Mode](workspaces.md#workspace-mode).
+
 ## Monitor Detection
 
 Monitors are automatically enumerated and sorted left-to-right by their

--- a/website/src/guide/status-bar.md
+++ b/website/src/guide/status-bar.md
@@ -11,7 +11,7 @@ height = 28
 monitor = "all"      # "all", "primary", or 0-based index
 
 [colors]
-background = "base"      # Named Catppuccin color or hex
+background = "base"      # Named theme color or hex
 foreground = "text"
 accent = "blue"
 
@@ -41,9 +41,10 @@ The `monitor` field accepts:
 
 ## Colors
 
-Colors can be specified as hex values (`"#1e1e2e"`) or as named Catppuccin
-colors (`"base"`, `"text"`, `"blue"`, etc.). See [Theming](theming.md) for
-the full list of named colors.
+Colors can be specified as hex values (`"#1e1e2e"`) or as named theme
+colors (`"blue"`, `"green"`, `"mauve"`, etc.). The named-color palette
+depends on the active theme family (Catppuccin, Rosé Pine, Tokyo Night);
+see [Theming](theming.md) for the full list per family.
 
 | Setting | Description |
 |---------|-------------|


### PR DESCRIPTION
## Summary

Adds a dedicated [Cheatsheet](https://github.com/jmelosegui/mosaico/blob/docs/refresh-and-cheatsheet/website/src/guide/cheatsheet.md) page and refreshes the rest of the user-facing guides to match what mosaico actually ships today.

The cheatsheet is the new marquee deliverable: a one-page reference card covering every default keyboard shortcut and its CLI equivalent, grouped by category (focus, move, workspaces, layout, window, daemon) plus a quick "at a glance" block at the top. Linked from the mdBook nav, the getting-started flow, and the keybindings reference.

## What changed in each file

- **`website/src/SUMMARY.md`** -- nav: new `[Cheatsheet]` entry between Getting Started and CLI Commands.
- **`website/src/guide/cheatsheet.md`** (new) -- structured shortcut reference + theme/border config snippets at the bottom.
- **`website/src/README.md`** (docs landing page) -- embedded the project screenshot from the root README, refreshed the feature list to mention the three layout algorithms, three theme families, per-window borders (focused / monocle / unfocused), and the pause/unpause hotkey.
- **`website/src/guide/getting-started.md`** -- keybindings table now lists `Alt + M`, `Alt + N`, and `Alt + Shift + P` alongside the existing focus/move/workspace lines. New "Pick a Theme" step covers the three families. "Next Steps" points to the cheatsheet, focus borders, and theming.
- **`website/src/guide/keybindings.md`** -- table gains `Alt + M` (minimize-focused) and `Alt + Shift + P` (toggle-pause); action reference gains `minimize-focused`. Top of page links to the cheatsheet.
- **`website/src/guide/multi-monitor.md`** -- brief note pointing at workspace mode for users who want every monitor to switch in lockstep.
- **`website/src/guide/status-bar.md`** -- replace "Catppuccin color" wording with theme-family-agnostic "named theme color"; link the theming guide.

## Test plan

- [x] `mdbook build` runs locally without errors (verified).
- [x] Open the rendered docs and confirm the Cheatsheet page appears in the sidebar between Getting Started and CLI Commands.
- [x] Confirm the docs landing page now shows the project screenshot.
- [x] Confirm getting-started shows `Alt + M`, `Alt + N`, `Alt + Shift + P` and links to the cheatsheet.
- [x] Confirm keybindings.md table includes the same three plus `minimize-focused` in the action reference.
- [x] Confirm multi-monitor.md mentions the workspace mode option and links to workspaces.

No code changes.
