### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "mosaico-core",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico-windows"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "mosaico-core",
  "serde_json",

--- a/crates/mosaico-core/Cargo.toml
+++ b/crates/mosaico-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Platform-agnostic core types and traits for Mosaico"
 license = "MIT"

--- a/crates/mosaico-windows/Cargo.toml
+++ b/crates/mosaico-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico-windows"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Windows platform implementation for Mosaico"
 license = "MIT"

--- a/crates/mosaico/Cargo.toml
+++ b/crates/mosaico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "A cross-platform tiling window manager"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps every workspace crate from `0.8.0` to `0.9.0`.

After this lands, tag `v0.9.0` from main and the existing `release.yml` workflow will build the Windows binary, package it, and open a GitHub Release with auto-generated notes from the merge commits since `v0.8.0`.

## Highlights since 0.8.0

### Features
- Per-monitor (default) and global workspace switching modes (#8)
- Per-window border overlays with focused, monocle, and unfocused color states under `[borders.colors]` (#11)
- Two new theme families alongside Catppuccin: **Rosé Pine** (`main` / `moon` / `dawn`) and **Tokyo Night** (`night` / `storm` / `day`) (#14)

### Fixes
- Pick the geometrically nearest window when crossing monitors with `Alt + H/L` (#6)
- `[workspaces.layouts]` string keys now actually deserialize as `u8` so per-workspace layout overrides work end-to-end (#10)

### Refactors / breaking changes
- `borders.focused` and `borders.monocle` moved to `borders.colors.focused` and `borders.colors.monocle`. Existing configs are auto-migrated on next daemon start with a backup at `config.toml.pre-0.9.bak` (#9). The minor bump (vs. patch) is justified primarily by this rename, plus the feature additions above.

### Docs
- New cheatsheet page at `website/src/guide/cheatsheet.md` plus a refresh of getting-started, keybindings, multi-monitor, status-bar, and the docs landing page (#15)

### CI / housekeeping
- Skip Azure docs deploy on PR events so preview environments stop accumulating (#12)
- Plan housekeeping: phases 1, 29, and 31 marked Complete (#13)

## Test plan

- [x] CI Check job is green (build + fmt + clippy + tests).
- [x] After merge, run `git tag v0.9.0 <merge-commit>` and `git push origin v0.9.0`.
- [x] Confirm the `Release` workflow runs successfully on the tag.
- [x] Confirm a new GitHub Release `v0.9.0` is created with the `mosaico-windows-amd64.zip` asset attached.
- [x] Run `mosaico --version` against the new binary; confirm it reports `0.9.0`.
