### PR TITLE
fix(monocle): exit monocle when focusing a different window via mouse…

### DIFF
--- a/crates/mosaico-windows/src/tiling/event_handler.rs
+++ b/crates/mosaico-windows/src/tiling/event_handler.rs
@@ -111,6 +111,10 @@ impl TilingManager {
                                 self.goto_workspace((ws_idx + 1) as u8);
                                 self.focus_from_mouse = true;
                                 self.focus_and_update_border(*hwnd);
+                                let ws = self.monitors[mon_idx].active_ws();
+                                if ws.monocle() && ws.monocle_window() != Some(*hwnd) {
+                                    self.exit_monocle(mon_idx);
+                                }
                             }
                         } else {
                             // Inside cooldown: stale deferred focus event
@@ -127,7 +131,12 @@ impl TilingManager {
                     self.focused_window = Some(*hwnd);
                     self.focused_monitor = idx;
                     self.focused_maximized = Window::from_raw(*hwnd).is_maximized();
-                    self.update_border();
+                    let ws = self.monitors[idx].active_ws();
+                    if ws.monocle() && ws.monocle_window() != Some(*hwnd) {
+                        self.exit_monocle(idx);
+                    } else {
+                        self.update_border();
+                    }
                     self.focus_from_mouse = false;
                 } else if let Some(owner) = Window::from_raw(*hwnd).owner()
                     && let Some(idx) = self.owning_monitor(owner)
@@ -213,6 +222,16 @@ impl TilingManager {
                 // Handled by the daemon loop, not here.
             }
         }
+    }
+
+    /// Exits monocle mode on the active workspace of `mon_idx` and
+    /// re-applies the tiled layout so the prior monocle window is
+    /// restored to its tiled rect.
+    fn exit_monocle(&mut self, mon_idx: usize) {
+        let ws = self.monitors[mon_idx].active_ws_mut();
+        ws.set_monocle(false);
+        ws.set_monocle_window(None);
+        self.apply_layout_on(mon_idx);
     }
 
     /// Removes a window from the tiling layout, clears focus/monocle state


### PR DESCRIPTION
## Summary
  - When monocle is active and the user focuses a different window via mouse, taskbar click, or alt-tab, exit monocle and re-apply
  the tiled layout so the prior monocle window is restored to its tiled rect.
  - Previously the new window kept its stale tiled rect while the old monocle window stayed full-screen, leaving the layout
  inconsistent.
  - Adds `exit_monocle` helper in `tiling/event_handler.rs`; both branches of the `Focused` handler (same-workspace and
  cross-workspace taskbar/alt-tab) check whether the focused hwnd differs from the workspace's monocle window and call it.

  ## Test plan
  - [x] `cargo build -p mosaico-windows`
  - [x] `cargo test -p mosaico-windows --lib monocle` (9 passed)
  - [x] Manual: tile 3 windows, toggle one to monocle, click another via taskbar — monocle exits and tiled layout is restored
  - [x] Manual: same scenario via alt-tab
  - [x] Manual: alt-tab to a window on another workspace whose workspace is in monocle — destination workspace exits monocle