### PR TITLE
fix(monocle): exit monocle on target monitor when moving a window to it

### DIFF
--- a/crates/mosaico-windows/src/tiling/event_handler.rs
+++ b/crates/mosaico-windows/src/tiling/event_handler.rs
@@ -227,7 +227,7 @@ impl TilingManager {
     /// Exits monocle mode on the active workspace of `mon_idx` and
     /// re-applies the tiled layout so the prior monocle window is
     /// restored to its tiled rect.
-    fn exit_monocle(&mut self, mon_idx: usize) {
+    pub(super) fn exit_monocle(&mut self, mon_idx: usize) {
         let ws = self.monitors[mon_idx].active_ws_mut();
         ws.set_monocle(false);
         ws.set_monocle_window(None);

--- a/crates/mosaico-windows/src/tiling/navigation.rs
+++ b/crates/mosaico-windows/src/tiling/navigation.rs
@@ -141,6 +141,9 @@ impl TilingManager {
         } else {
             self.monitors[target].active_ws_mut().add(hwnd);
         }
+        if self.monitors[target].active_ws().monocle() {
+            self.exit_monocle(target);
+        }
         self.apply_layout_on(source);
         self.apply_layout_on(target);
         self.focused_monitor = target;


### PR DESCRIPTION
 ## Summary
  - Moving a window into a monitor whose active workspace is in
  monocle mode now exits monocle on that monitor before applying
   the new layout.
  - Previously the moved window kept its source position because
   the target's monocle layout only repositioned the monocle
  window, leaving the moved window stranded.
  - `navigation.rs::move_to_monitor` checks the target's active
  workspace and calls `exit_monocle(target)` before re-tiling.
  - Bumps `exit_monocle` visibility to `pub(super)` so
  `navigation.rs` can reuse it.

  ## Notes
  Stacked on `fix/monocle-exit-on-focus-change` — it depends on
  the `exit_monocle` helper added there. Merge that one first,
  or set this PR's base accordingly.

  ## Test plan
  - [x] `cargo build -p mosaico-windows`
  - [x] `cargo test -p mosaico-windows --lib monocle` (9 passed)
  - [x] Manual: monocle on monitor A, focus monitor B, move a
  window from B → A — A exits monocle and the window is tiled in
