### PR TITLE
fix(focus): drop stale Win32 focus echoes from our own set_foreground

### DIFF
--- a/crates/mosaico-windows/src/tiling/event_handler.rs
+++ b/crates/mosaico-windows/src/tiling/event_handler.rs
@@ -87,6 +87,13 @@ impl TilingManager {
                 }
             }
             WindowEvent::Focused { hwnd } => {
+                if self.is_stale_focus_echo(*hwnd) {
+                    mosaico_core::log_debug!(
+                        "focus-suppressed 0x{:X} (stale Win32 echo of our own set_foreground)",
+                        hwnd
+                    );
+                    return;
+                }
                 if let Some(idx) = self.owning_monitor(*hwnd) {
                     // Check if the window is on a non-active workspace
                     // (e.g. user clicked a cloaked window's taskbar icon).

--- a/crates/mosaico-windows/src/tiling/focus.rs
+++ b/crates/mosaico-windows/src/tiling/focus.rs
@@ -37,6 +37,7 @@ impl TilingManager {
     pub(super) fn focus_and_update_border(&mut self, hwnd: usize) {
         self.focused_window = Some(hwnd);
         self.focused_maximized = Window::from_raw(hwnd).is_maximized();
+        self.record_focus_intent(hwnd);
         Window::from_raw(hwnd).set_foreground();
         if self.mouse_follows_focus && !self.focus_from_mouse {
             Self::move_cursor_to_window(hwnd);
@@ -54,6 +55,32 @@ impl TilingManager {
         {
             Self::move_cursor_to_window(hwnd);
         }
+    }
+
+    /// Records that we just asked Win32 to focus `hwnd`, so the
+    /// `Focused` event handler can recognize stale OS echoes and
+    /// discard them. Keeps at most 8 entries from the last 1.5s.
+    pub(super) fn record_focus_intent(&mut self, hwnd: usize) {
+        let now = std::time::Instant::now();
+        let cutoff = now - std::time::Duration::from_millis(1500);
+        self.focus_intents.retain(|(_, t)| *t >= cutoff);
+        self.focus_intents.push_back((hwnd, now));
+        while self.focus_intents.len() > 8 {
+            self.focus_intents.pop_front();
+        }
+    }
+
+    /// Returns true if `hwnd` matches a previously issued
+    /// `set_foreground` intent that is no longer the most recent —
+    /// i.e. a stale Win32 focus echo we should ignore.
+    pub(super) fn is_stale_focus_echo(&mut self, hwnd: usize) -> bool {
+        let cutoff = std::time::Instant::now() - std::time::Duration::from_millis(1500);
+        self.focus_intents.retain(|(_, t)| *t >= cutoff);
+        let latest = self.focus_intents.back().map(|(h, _)| *h);
+        if latest == Some(hwnd) {
+            return false;
+        }
+        self.focus_intents.iter().any(|(h, _)| *h == hwnd)
     }
 
     /// Refreshes every border overlay to match the current layout and

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -116,6 +116,16 @@ pub struct TilingManager {
     /// that will never be managed (e.g. elevated Visual Studio).
     /// Cleared on rule reload; entries removed on `Destroyed`.
     adopt_rejected: HashSet<usize>,
+    /// Recent `set_foreground` targets with the time they were issued.
+    ///
+    /// Win32 delivers `EVENT_OBJECT_FOCUS` for each window we focus
+    /// asynchronously, often hundreds of milliseconds late. When the
+    /// user navigates rapidly (e.g. several `alt+h` presses in quick
+    /// succession), stale echoes for intermediate windows arrive after
+    /// we've already advanced and would rewind `focused_window` if
+    /// processed. We keep the last few intents here so the `Focused`
+    /// handler can recognize and discard those echoes.
+    focus_intents: std::collections::VecDeque<(usize, Instant)>,
 }
 
 impl TilingManager {
@@ -169,6 +179,7 @@ impl TilingManager {
             ws_switch_cooldown: None,
             self_elevated,
             adopt_rejected: HashSet::new(),
+            focus_intents: std::collections::VecDeque::new(),
         };
 
         for win in enumerate::enumerate_windows()? {


### PR DESCRIPTION
## Summary
  - Rapid `alt+h` / `alt+l` navigation made the focus border bounce back to intermediate windows. Win32 delivers
  `EVENT_OBJECT_FOCUS` asynchronously (often 100 ms+ late); when several focus actions are issued in quick succession, the late echoes for intermediate hwnds arrive after the manager has already advanced and would rewind focused_window` /border.
  - Now we record every `set_foreground` target in a small intent queue (up to 8 entries, 1.5 s window). In the `Focused`
   handler, if the incoming hwnd matches a non-most-recent intent, it's treated as a stale echo and dropped. Genuine
  external focus changes (taskbar clicks, alt-tab to windows mosaico didn't focus) aren't in the queue and process  normally.

  ## Notes
  - Stacked on `fix/monocle-exit-on-cross-monitor-move`. Merge the prior PRs first, or set this PR's base accordingly.
  - A follow-up PR will tackle the perceived lag when many focus actions queue up in the daemon — splitting border/icon
  updates (instant, mosaico-owned) from `SetForegroundWindow` (slow, deferred to the final target in the batch).

  ## Test plan
  - [x] `cargo build --release`
  - [x] `cargo test -p mosaico-windows --lib monocle`
  - [x] Manual: rapid alt+h/alt+l navigation no longer bounces
  back to intermediate windows
  - [x] Manual: clicking a window via taskbar still focuses it
  (intent queue doesn't suppress genuine external focus changes)