### PR TITLE
perf(focus): defer and coalesce SetForegroundWindow across rapid actions

### DIFF
--- a/crates/mosaico-windows/src/daemon_loop.rs
+++ b/crates/mosaico-windows/src/daemon_loop.rs
@@ -109,10 +109,27 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
     let mut hotkeys_paused = false;
 
     while !should_stop {
-        // Block until at least one message arrives.
-        let first = match rx.recv() {
-            Ok(msg) => msg,
-            Err(_) => break,
+        // Block until at least one message arrives. If a foreground
+        // change is pending from the previous iteration, only wait
+        // briefly: if no new action arrives, flush the deferred
+        // `SetForegroundWindow` and go back to a normal blocking
+        // recv. This coalesces rapid focus navigation so the OS only
+        // sees the *final* target while the border and bar icon keep
+        // up with every keypress.
+        let first = if manager.has_pending_foreground() {
+            match rx.recv_timeout(std::time::Duration::from_millis(25)) {
+                Ok(msg) => msg,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    manager.flush_pending_foreground();
+                    continue;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        } else {
+            match rx.recv() {
+                Ok(msg) => msg,
+                Err(_) => break,
+            }
         };
 
         // Drain all queued messages so we can prioritise.
@@ -193,6 +210,12 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
         if needs_bar_update {
             bar_mgr.update(&manager.bar_states(&get_update(), hotkeys_paused));
         }
+
+        // The deferred `SetForegroundWindow` for the final focus
+        // target is flushed by the recv-timeout path at the top of
+        // the next iteration, after a short quiet window. That way
+        // rapid focus navigation coalesces across iterations, not
+        // just within a single drained batch.
     }
 
     manager.restore_all_windows();

--- a/crates/mosaico-windows/src/tiling/focus.rs
+++ b/crates/mosaico-windows/src/tiling/focus.rs
@@ -32,18 +32,42 @@ impl TilingManager {
         }
     }
 
-    /// Sets the focused window, brings it to the foreground, and
-    /// refreshes the focus border.
+    /// Sets the focused window and refreshes the focus border
+    /// immediately, but defers the cross-process `SetForegroundWindow`
+    /// call until the end of the current daemon batch.
+    ///
+    /// When several focus actions are processed in quick succession,
+    /// only the final target ends up reaching the OS, so the user
+    /// sees the border (and bar icon, which reads `focused_window`)
+    /// race across windows at full keyboard speed while the slow
+    /// foreground change happens once.
     pub(super) fn focus_and_update_border(&mut self, hwnd: usize) {
         self.focused_window = Some(hwnd);
         self.focused_maximized = Window::from_raw(hwnd).is_maximized();
-        self.record_focus_intent(hwnd);
-        Window::from_raw(hwnd).set_foreground();
-        if self.mouse_follows_focus && !self.focus_from_mouse {
-            Self::move_cursor_to_window(hwnd);
-        }
+        self.pending_foreground = Some((hwnd, self.focus_from_mouse));
         self.focus_from_mouse = false;
         self.update_border();
+    }
+
+    /// Returns true if a deferred `SetForegroundWindow` is waiting
+    /// to be flushed.
+    pub fn has_pending_foreground(&self) -> bool {
+        self.pending_foreground.is_some()
+    }
+
+    /// Applies the deferred `SetForegroundWindow` (and cursor move,
+    /// if `mouse_follows_focus` is on) for the last focus request in
+    /// the current batch. Called by the daemon loop after each
+    /// iteration of action + event processing.
+    pub fn flush_pending_foreground(&mut self) {
+        let Some((hwnd, from_mouse)) = self.pending_foreground.take() else {
+            return;
+        };
+        self.record_focus_intent(hwnd);
+        Window::from_raw(hwnd).set_foreground();
+        if self.mouse_follows_focus && !from_mouse {
+            Self::move_cursor_to_window(hwnd);
+        }
     }
 
     /// Moves the cursor to the focused window if `mouse_follows_focus` is

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -116,6 +116,18 @@ pub struct TilingManager {
     /// that will never be managed (e.g. elevated Visual Studio).
     /// Cleared on rule reload; entries removed on `Destroyed`.
     adopt_rejected: HashSet<usize>,
+    /// Deferred `SetForegroundWindow` target for the current batch.
+    ///
+    /// When several focus actions are processed back-to-back, calling
+    /// `SetForegroundWindow` on every intermediate window is expensive
+    /// (Win32 cross-process IPC + foreground-window policy checks,
+    /// often 50–150 ms per call). The internal `focused_window`,
+    /// border, and bar are updated synchronously, but the actual OS
+    /// foreground change is deferred and only run for the *last*
+    /// target in the batch by `flush_pending_foreground`. The boolean
+    /// snapshots `focus_from_mouse` at the time of the request so the
+    /// flush can decide whether to move the cursor.
+    pending_foreground: Option<(usize, bool)>,
     /// Recent `set_foreground` targets with the time they were issued.
     ///
     /// Win32 delivers `EVENT_OBJECT_FOCUS` for each window we focus
@@ -179,6 +191,7 @@ impl TilingManager {
             ws_switch_cooldown: None,
             self_elevated,
             adopt_rejected: HashSet::new(),
+            pending_foreground: None,
             focus_intents: std::collections::VecDeque::new(),
         };
 


### PR DESCRIPTION
## Summary
  Each focus action used to call `SetForegroundWindow` synchronously — a cross-process Win32 IPC that takes ~50–150
  ms per call. Rapid `alt+h` / `alt+l` navigation queued one OS foreground change per keypress, so focus kept shifting visibly for seconds after the user stopped pressing.

  Focus is now split into two phases:

  - **Synchronous (instant).** `focus_and_update_border` updates `focused_window`, `focused_maximized`, and the border. The bar icon picks up the new focus on its next paint via `bar_states`. No `SetForegroundWindow`, no cursor move.
  - **Deferred (coalesced).** The daemon loop stores the latest target in `pending_foreground` and flushes it via  `SetForegroundWindow` once, after a 25 ms quiet window on the action channel. Any new action inside the quiet window resets the timer, so a burst of keypresses produces a single OS foreground change at the end.

  The `recv_timeout` path only kicks in when a foreground change is pending; idle iterations still block on `recv()` exactly
  as before, so steady-state CPU is unchanged.

  ## Notes
  - Stacked on `fix/suppress-stale-focus-echoes`. Merge prior PRs first, or set this PR's base accordingly.
  - 25 ms was chosen empirically — long enough to coalesce key-repeat / rapid mashing, short enough to feel instant on a
  single keypress.

  ## Test plan
  - [x] `cargo build --release`
  - [x] `cargo test -p mosaico-windows --lib` (60 passed)
  - [x] Manual: rapid h+l+h+l+h+l+h+l — border and bar icon
  track each keypress, OS foreground settles on the final window
  - [x] Manual: single alt+h still feels instant (no perceptible
   25 ms hitch)
  - [x] Manual: taskbar click on a different window still
  focuses it (external focus path unaffected)