### PR TITLE
perf(move): defer and coalesce SetWindowPos across rapid move actions

### DIFF
--- a/crates/mosaico-windows/src/daemon_loop.rs
+++ b/crates/mosaico-windows/src/daemon_loop.rs
@@ -116,10 +116,11 @@ pub(super) fn daemon_loop() -> WindowResult<()> {
         // recv. This coalesces rapid focus navigation so the OS only
         // sees the *final* target while the border and bar icon keep
         // up with every keypress.
-        let first = if manager.has_pending_foreground() {
+        let first = if manager.has_pending_foreground() || manager.has_pending_retile() {
             match rx.recv_timeout(std::time::Duration::from_millis(25)) {
                 Ok(msg) => msg,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
+                    manager.flush_pending_retile();
                     manager.flush_pending_foreground();
                     continue;
                 }

--- a/crates/mosaico-windows/src/tiling/focus.rs
+++ b/crates/mosaico-windows/src/tiling/focus.rs
@@ -55,6 +55,28 @@ impl TilingManager {
         self.pending_foreground.is_some()
     }
 
+    /// Marks a monitor as needing its layout re-applied. The actual
+    /// `SetWindowPos` storm is run by `flush_pending_retile` after
+    /// the daemon's coalescing quiet window.
+    pub(super) fn mark_retile(&mut self, monitor_idx: usize) {
+        self.pending_retile.insert(monitor_idx);
+    }
+
+    /// Returns true if at least one monitor is waiting to be retiled.
+    pub fn has_pending_retile(&self) -> bool {
+        !self.pending_retile.is_empty()
+    }
+
+    /// Applies the deferred layout on every monitor marked dirty by
+    /// `mark_retile`. Called by the daemon loop together with
+    /// `flush_pending_foreground`.
+    pub fn flush_pending_retile(&mut self) {
+        let monitors: Vec<usize> = self.pending_retile.drain().collect();
+        for idx in monitors {
+            self.apply_layout_on(idx);
+        }
+    }
+
     /// Applies the deferred `SetForegroundWindow` (and cursor move,
     /// if `mouse_follows_focus` is on) for the last focus request in
     /// the current batch. Called by the daemon loop after each

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -116,6 +116,15 @@ pub struct TilingManager {
     /// that will never be managed (e.g. elevated Visual Studio).
     /// Cleared on rule reload; entries removed on `Destroyed`.
     adopt_rejected: HashSet<usize>,
+    /// Monitors that have outstanding layout work to apply.
+    ///
+    /// `move_direction` and `move_to_monitor` mutate the workspace
+    /// data structure (swap / remove / insert) but defer the actual
+    /// `SetWindowPos` storm to `flush_pending_retile`. Several rapid
+    /// move actions therefore touch the data structure many times
+    /// but only repaint window positions once, after the daemon's
+    /// coalescing quiet window.
+    pending_retile: HashSet<usize>,
     /// Deferred `SetForegroundWindow` target for the current batch.
     ///
     /// When several focus actions are processed back-to-back, calling
@@ -191,6 +200,7 @@ impl TilingManager {
             ws_switch_cooldown: None,
             self_elevated,
             adopt_rejected: HashSet::new(),
+            pending_retile: HashSet::new(),
             pending_foreground: None,
             focus_intents: std::collections::VecDeque::new(),
         };

--- a/crates/mosaico-windows/src/tiling/navigation.rs
+++ b/crates/mosaico-windows/src/tiling/navigation.rs
@@ -144,8 +144,8 @@ impl TilingManager {
         if self.monitors[target].active_ws().monocle() {
             self.exit_monocle(target);
         }
-        self.apply_layout_on(source);
-        self.apply_layout_on(target);
+        self.mark_retile(source);
+        self.mark_retile(target);
         self.focused_monitor = target;
         self.update_border();
         self.move_cursor_to_focused();
@@ -156,7 +156,7 @@ impl TilingManager {
         self.monitors[self.focused_monitor]
             .active_ws_mut()
             .swap(a, b);
-        self.apply_layout_on(self.focused_monitor);
+        self.mark_retile(self.focused_monitor);
         self.update_border();
         self.move_cursor_to_focused();
     }


### PR DESCRIPTION
## Summary
  Rapid `shift+alt+h` / `shift+alt+l` move spam called `apply_layout_on` on every step, and each call issued one or
  more cross-process `SetWindowPos` calls. Several moves in quick succession piled up these calls and the user saw windows  visibly thrash for seconds after they stopped pressing keys.

  Same coalescing pattern as the focus PR, applied to moves:

  - `swap_and_retile` and `move_to_monitor` now mutate the workspace data structure and call `mark_retile(monitor)`
  instead of `apply_layout_on` directly. The data structure reaches its final state instantly; window positions stay put.
  - The daemon loop's existing 25 ms `recv_timeout` quiet window  already triggers a flush; it now also calls  `flush_pending_retile`, which drains the dirty-monitor set and  runs `apply_layout_on` once per monitor.

  A burst of N moves therefore runs the data-structure swaps N times but pays the `SetWindowPos` cost only once on the final layout. Events and other code paths that need an immediate layout still call `apply_layout_on` directly.

  ## Notes
  Stacked on `perf/coalesce-set-foreground`. Merge prior PRs first, or set this PR's base accordingly.

  ## Test plan
  - [x] `cargo build --release`
  - [x] `cargo test -p mosaico-windows --lib` (60 passed)
  - [x] Manual: rapid shift+alt+h+l+h+l move spam — windows
  don't visibly thrash during the burst and settle in their
  final positions on quiet
  - [x] Manual: a single move still feels instant
  - [x] Manual: window destroy / workspace switch still retiles
  immediately (event path unchanged)