### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "clap",
  "mosaico-core",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "mosaico-windows"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "mosaico-core",
  "serde_json",

--- a/crates/mosaico-core/Cargo.toml
+++ b/crates/mosaico-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Platform-agnostic core types and traits for Mosaico"
 license = "MIT"

--- a/crates/mosaico-windows/Cargo.toml
+++ b/crates/mosaico-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico-windows"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Windows platform implementation for Mosaico"
 license = "MIT"

--- a/crates/mosaico/Cargo.toml
+++ b/crates/mosaico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosaico"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "A cross-platform tiling window manager"
 license = "MIT"


### PR DESCRIPTION
Bumps every workspace crate from 0.9.0 to 0.9.1.

Six fixes/perf improvements have landed since v0.9.0:

- fix(monocle): exit monocle when focusing a different window via mouse/taskbar (#17)
- fix(monocle): exit monocle on target monitor when moving a window to it (#18)
- fix(focus): drop stale Win32 focus echoes from our own set_foreground (#19)
- perf(focus): defer and coalesce SetForegroundWindow across rapid actions (#20)
- perf(move): defer and coalesce SetWindowPos across rapid move actions (#21)
- fix(border): align border SetWindowPos with window moves during retile (#23)

No new features, so this is a patch release.