### PR TITLE
fix(focus): anchor foreground to empty workspaces; cloak adopted windows during tile

### DIFF
--- a/crates/mosaico-windows/src/focus_anchor.rs
+++ b/crates/mosaico-windows/src/focus_anchor.rs
@@ -17,8 +17,8 @@ use std::sync::Once;
 use mosaico_core::{Rect, WindowResult};
 use windows::Win32::Foundation::{COLORREF, HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CreateWindowExW, DefWindowProcW, DestroyWindow, HWND_TOP, LWA_ALPHA, RegisterClassW,
-    SW_HIDE, SW_SHOWNA, SWP_NOSIZE, SetForegroundWindow, SetLayeredWindowAttributes, SetWindowPos,
+    CreateWindowExW, DefWindowProcW, DestroyWindow, HWND_TOP, LWA_ALPHA, RegisterClassW, SW_HIDE,
+    SW_SHOWNA, SWP_NOSIZE, SetForegroundWindow, SetLayeredWindowAttributes, SetWindowPos,
     ShowWindow, WNDCLASSW, WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_POPUP,
 };
 use windows::core::PCWSTR;

--- a/crates/mosaico-windows/src/focus_anchor.rs
+++ b/crates/mosaico-windows/src/focus_anchor.rs
@@ -1,0 +1,158 @@
+//! A hidden focus-holder window used to anchor the foreground to a
+//! specific monitor when the active workspace on that monitor is empty.
+//!
+//! Win32 tracks a single "foreground window" globally, and transient
+//! overlays like PowerToys Run restore focus to whatever was foreground
+//! before they opened.  When mosaico switches focus to a monitor whose
+//! workspace has no windows, there is nothing to take foreground — so
+//! the previous monitor's window keeps it, and newly spawned apps land
+//! on the wrong monitor.
+//!
+//! This module creates a single 1x1 layered popup window that can be
+//! repositioned onto any monitor and set as foreground, giving Windows
+//! a real target for foreground tracking without being visible to the user.
+
+use std::sync::Once;
+
+use mosaico_core::{Rect, WindowResult};
+use windows::Win32::Foundation::{COLORREF, HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DestroyWindow, HWND_TOP, LWA_ALPHA, RegisterClassW,
+    SW_HIDE, SW_SHOWNA, SWP_NOSIZE, SetForegroundWindow, SetLayeredWindowAttributes, SetWindowPos,
+    ShowWindow, WNDCLASSW, WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_POPUP,
+};
+use windows::core::PCWSTR;
+
+/// A 1x1 invisible popup window used as a foreground anchor.
+pub struct FocusAnchor {
+    hwnd: HWND,
+}
+
+static REGISTER_CLASS: Once = Once::new();
+const CLASS_NAME: &[u16] = &[
+    b'M' as u16,
+    b'o' as u16,
+    b's' as u16,
+    b'a' as u16,
+    b'i' as u16,
+    b'c' as u16,
+    b'o' as u16,
+    b'F' as u16,
+    b'o' as u16,
+    b'c' as u16,
+    b'u' as u16,
+    b's' as u16,
+    b'A' as u16,
+    b'n' as u16,
+    b'c' as u16,
+    b'h' as u16,
+    b'o' as u16,
+    b'r' as u16,
+    0,
+];
+
+fn ensure_class_registered() {
+    REGISTER_CLASS.call_once(|| {
+        let wc = WNDCLASSW {
+            lpfnWndProc: Some(anchor_wnd_proc),
+            lpszClassName: PCWSTR(CLASS_NAME.as_ptr()),
+            ..Default::default()
+        };
+        // SAFETY: RegisterClassW is called once (guarded by Once) with a
+        // valid WNDCLASSW whose string pointer is a static array.
+        unsafe {
+            RegisterClassW(&wc);
+        }
+    });
+}
+
+unsafe extern "system" fn anchor_wnd_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    // SAFETY: DefWindowProcW is the default handler required by WNDPROC.
+    unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
+}
+
+impl FocusAnchor {
+    /// Creates a hidden 1x1 layered anchor window.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the Win32 window could not be created.
+    pub fn new() -> WindowResult<Self> {
+        ensure_class_registered();
+
+        let ex = WS_EX_LAYERED | WS_EX_TOOLWINDOW;
+        // SAFETY: CreateWindowExW creates a popup window using the
+        // registered class. The class name pointer is valid for the
+        // lifetime of the process (static array).
+        let hwnd = unsafe {
+            CreateWindowExW(
+                ex,
+                PCWSTR(CLASS_NAME.as_ptr()),
+                PCWSTR::null(),
+                WS_POPUP,
+                0,
+                0,
+                1,
+                1,
+                None,
+                None,
+                None,
+                None,
+            )?
+        };
+
+        // SAFETY: SetLayeredWindowAttributes makes the window fully
+        // transparent. The HWND was just created above.
+        unsafe {
+            let _ = SetLayeredWindowAttributes(hwnd, COLORREF(0), 0, LWA_ALPHA);
+        }
+
+        Ok(Self { hwnd })
+    }
+
+    /// Positions the anchor at the center of the given work area and
+    /// sets it as the foreground window.
+    ///
+    /// Call when focus moves to a monitor whose active workspace is
+    /// empty, so that subsequent new-window placement respects that
+    /// monitor instead of the previous foreground monitor.
+    pub fn activate_on(&self, work_area: &Rect) {
+        let x = work_area.x + work_area.width / 2;
+        let y = work_area.y + work_area.height / 2;
+        // SAFETY: SetWindowPos, ShowWindow, and SetForegroundWindow are
+        // safe to call with the anchor's valid HWND.
+        unsafe {
+            let _ = SetWindowPos(self.hwnd, Some(HWND_TOP), x, y, 0, 0, SWP_NOSIZE);
+            let _ = ShowWindow(self.hwnd, SW_SHOWNA);
+            let _ = SetForegroundWindow(self.hwnd);
+        }
+    }
+
+    /// Hides the anchor.  Called when a real window takes focus again.
+    pub fn hide(&self) {
+        // SAFETY: ShowWindow is safe to call with the anchor's valid HWND.
+        unsafe {
+            let _ = ShowWindow(self.hwnd, SW_HIDE);
+        }
+    }
+
+    /// Returns the underlying HWND as a `usize`, for comparison with
+    /// hwnds reported by Win32 events.
+    pub fn hwnd(&self) -> usize {
+        self.hwnd.0 as usize
+    }
+}
+
+impl Drop for FocusAnchor {
+    fn drop(&mut self) {
+        // SAFETY: DestroyWindow is safe to call with a valid HWND we own.
+        unsafe {
+            let _ = DestroyWindow(self.hwnd);
+        }
+    }
+}

--- a/crates/mosaico-windows/src/lib.rs
+++ b/crates/mosaico-windows/src/lib.rs
@@ -16,6 +16,9 @@ pub mod bar_manager;
 /// Border overlay windows for visual focus indicators.
 pub mod border;
 
+/// Hidden focus-holder window for anchoring foreground to a monitor.
+pub mod focus_anchor;
+
 /// Downloads community rules from the mosaico-rules repository.
 pub mod community_rules;
 

--- a/crates/mosaico-windows/src/tiling/event_handler.rs
+++ b/crates/mosaico-windows/src/tiling/event_handler.rs
@@ -87,6 +87,16 @@ impl TilingManager {
                 }
             }
             WindowEvent::Focused { hwnd } => {
+                // Ignore focus events fired by our own hidden focus
+                // anchor — it's not a managed window, and running the
+                // adopt/owner fallbacks on it is pointless work.
+                if self
+                    .focus_anchor
+                    .as_ref()
+                    .is_some_and(|a| a.hwnd() == *hwnd)
+                {
+                    return;
+                }
                 if self.is_stale_focus_echo(*hwnd) {
                     mosaico_core::log_debug!(
                         "focus-suppressed 0x{:X} (stale Win32 echo of our own set_foreground)",
@@ -95,6 +105,17 @@ impl TilingManager {
                     return;
                 }
                 if let Some(idx) = self.owning_monitor(*hwnd) {
+                    // If the user just jumped to an empty workspace on
+                    // another monitor and a transient event (e.g. a
+                    // launcher closing) is pulling foreground back to
+                    // the previous monitor, suppress the update so the
+                    // imminent Created window still targets the anchored
+                    // monitor via `focused_monitor`.
+                    if let Some(anchored) = self.pending_empty_spawn
+                        && anchored != idx
+                    {
+                        return;
+                    }
                     // Check if the window is on a non-active workspace
                     // (e.g. user clicked a cloaked window's taskbar icon).
                     // Switch to that workspace so the window becomes visible.
@@ -148,6 +169,11 @@ impl TilingManager {
                 } else if let Some(owner) = Window::from_raw(*hwnd).owner()
                     && let Some(idx) = self.owning_monitor(owner)
                 {
+                    if let Some(anchored) = self.pending_empty_spawn
+                        && anchored != idx
+                    {
+                        return;
+                    }
                     // An owned window (dialog, property sheet) got focus.
                     //
                     // Due to a Win32 race condition, dialogs created on
@@ -285,6 +311,13 @@ impl TilingManager {
                     .or_else(|| ws.handles().first().copied());
                 if let Some(new_hwnd) = replacement {
                     self.focus_and_update_border(new_hwnd);
+                } else {
+                    // Active workspace is now empty.  Re-anchor focus so
+                    // Windows restoring foreground to a window on another
+                    // monitor (which it does when the last window closes)
+                    // doesn't drag `focused_monitor` away before the next
+                    // launcher-spawned window is created.
+                    self.anchor_focus_to_monitor(mon_idx);
                 }
             }
         }

--- a/crates/mosaico-windows/src/tiling/focus.rs
+++ b/crates/mosaico-windows/src/tiling/focus.rs
@@ -44,6 +44,10 @@ impl TilingManager {
     pub(super) fn focus_and_update_border(&mut self, hwnd: usize) {
         self.focused_window = Some(hwnd);
         self.focused_maximized = Window::from_raw(hwnd).is_maximized();
+        self.pending_empty_spawn = None;
+        if let Some(anchor) = &self.focus_anchor {
+            anchor.hide();
+        }
         self.pending_foreground = Some((hwnd, self.focus_from_mouse));
         self.focus_from_mouse = false;
         self.update_border();
@@ -125,6 +129,32 @@ impl TilingManager {
         while self.focus_intents.len() > 8 {
             self.focus_intents.pop_front();
         }
+    }
+
+    /// Anchors focus to the given monitor when its active workspace is
+    /// empty.  Positions the cursor at the work-area center (if
+    /// `mouse_follows_focus`), activates the hidden focus-holder window,
+    /// and records the anchored monitor so subsequent transient focus
+    /// events (e.g. from PowerToys Run closing) do not drag
+    /// `focused_monitor` back to the previous monitor before a
+    /// user-launched app can spawn.
+    pub(super) fn anchor_focus_to_monitor(&mut self, idx: usize) {
+        let Some(mon) = self.monitors.get(idx) else {
+            return;
+        };
+        let work_area = mon.work_area;
+        if let Some(anchor) = &self.focus_anchor {
+            anchor.activate_on(&work_area);
+        }
+        if self.mouse_follows_focus {
+            let cx = work_area.x + work_area.width / 2;
+            let cy = work_area.y + work_area.height / 2;
+            // SAFETY: SetCursorPos is safe to call with screen coordinates.
+            unsafe {
+                let _ = SetCursorPos(cx, cy);
+            }
+        }
+        self.pending_empty_spawn = Some(idx);
     }
 
     /// Returns true if `hwnd` matches a previously issued

--- a/crates/mosaico-windows/src/tiling/helpers.rs
+++ b/crates/mosaico-windows/src/tiling/helpers.rs
@@ -149,6 +149,16 @@ impl TilingManager {
                 self.monitors[idx].active_ws().len()
             );
             frame::set_corner_preference(w.hwnd(), self.border_config.corner_style);
+            // Cloak the window during the reposition so the user doesn't
+            // see it flash at the OS-picked spawn location (e.g. apps
+            // that remember their last position on another monitor)
+            // before being tiled onto the focused monitor.  DWM cloaking
+            // is composition-level, so the window is hidden without
+            // firing Hidden events or losing the taskbar icon.
+            let needs_uncloak = !w.is_cloaked();
+            if needs_uncloak {
+                w.cloak();
+            }
             // Focus the new window before layout so monocle
             // mode sizes the correct window.
             self.focused_window = Some(hwnd);
@@ -162,6 +172,9 @@ impl TilingManager {
             self.apply_layout_on(idx);
             self.focus_from_mouse = false;
             self.focus_and_update_border(hwnd);
+            if needs_uncloak {
+                w.uncloak();
+            }
         }
     }
 

--- a/crates/mosaico-windows/src/tiling/mod.rs
+++ b/crates/mosaico-windows/src/tiling/mod.rs
@@ -20,6 +20,7 @@ use mosaico_core::{Action, Rect, WindowResult, Workspace};
 use crate::bar::BarState;
 use crate::border::Border;
 use crate::enumerate;
+use crate::focus_anchor::FocusAnchor;
 use crate::frame;
 use crate::monitor;
 use crate::window::Window;
@@ -68,6 +69,18 @@ pub struct TilingManager {
     /// and dropped when they leave.
     borders: HashMap<usize, Border>,
     border_config: BorderConfig,
+    /// Hidden anchor window used to hold foreground on a monitor whose
+    /// active workspace has no real windows.  Without this, transient
+    /// launchers (e.g. PowerToys Run) restore focus to the previous
+    /// monitor when they close, and newly spawned apps land there.
+    focus_anchor: Option<FocusAnchor>,
+    /// Set to `Some(idx)` after focus jumps to an empty workspace on
+    /// monitor `idx`.  While set, the `Focused` handler ignores events
+    /// from other monitors (they are transient — e.g. Windows restoring
+    /// focus after PowerToys Run closes) so the next `Created` window
+    /// lands on the anchored monitor via `focused_monitor`.  Cleared by
+    /// any explicit focus change or when a new window is adopted.
+    pending_empty_spawn: Option<usize>,
     focused_monitor: usize,
     focused_window: Option<usize>,
     /// Suppresses `Moved` event handling during programmatic layout.
@@ -179,6 +192,7 @@ impl TilingManager {
             })
             .collect();
 
+        let focus_anchor = FocusAnchor::new().ok();
         let self_elevated = crate::process::is_current_process_elevated();
 
         let mut manager = Self {
@@ -188,6 +202,8 @@ impl TilingManager {
             rules,
             borders: HashMap::new(),
             border_config,
+            focus_anchor,
+            pending_empty_spawn: None,
             focused_monitor: 0,
             focused_window: None,
             focused_maximized: false,

--- a/crates/mosaico-windows/src/tiling/navigation.rs
+++ b/crates/mosaico-windows/src/tiling/navigation.rs
@@ -83,6 +83,7 @@ impl TilingManager {
         } else {
             self.focused_window = None;
             self.update_border();
+            self.anchor_focus_to_monitor(idx);
         }
     }
 

--- a/crates/mosaico-windows/src/tiling/workspace.rs
+++ b/crates/mosaico-windows/src/tiling/workspace.rs
@@ -114,6 +114,7 @@ impl TilingManager {
             } else {
                 self.focused_window = None;
                 self.update_border();
+                self.anchor_focus_to_monitor(mon_idx);
             }
         }
 


### PR DESCRIPTION
 ## Summary
  - Add a hidden 1x1 focus-anchor window so foreground sticks to the focused
    monitor when its active workspace is empty (Win32 otherwise lets the previous
    monitor keep foreground, causing new launcher-spawned apps to land on the
    wrong monitor).
  - Suppress transient `Focused` echoes from other monitors while an
    empty-workspace anchor is pending, and ignore focus events from the anchor.
  - Re-anchor on `Destroyed` when the active workspace becomes empty, and on
    directional/workspace nav to an empty workspace.
  - DWM-cloak adopted windows during initial tile so apps that remember their
    last position don't flash on the wrong monitor before being moved.

  ## Test plan
  - [x] Focus empty workspace on monitor B; launch via PowerToys Run -> spawns on B.
  - [x] Close last window on a workspace; launch another app -> spawns on same monitor.
  - [x] Adopt a window opening on monitor A while focus is on monitor B -> no flash.
  - [x] Normal focus/move/swap across populated workspaces still works.